### PR TITLE
Test whether pipeline can be installed through autotools

### DIFF
--- a/.github/workflows/install_autotools.yaml
+++ b/.github/workflows/install_autotools.yaml
@@ -29,8 +29,8 @@ jobs:
           ./configure
           make
           make python
-          make install
-          make install-python
+          sudo make install
+          sudo make install-python
       - name: Check recipes
         # TODO: Actually check something here.
         run: |

--- a/.github/workflows/install_autotools.yaml
+++ b/.github/workflows/install_autotools.yaml
@@ -31,7 +31,7 @@ jobs:
           make python
           sudo make install
           sudo make install-python
-      - name: Check recipes
+      #- name: Check recipes
         # TODO: Actually check something here.
-        run: |
-          esorex --recipes
+      #  run: |
+      #    pyesorex --recipes

--- a/.github/workflows/install_autotools.yaml
+++ b/.github/workflows/install_autotools.yaml
@@ -1,0 +1,37 @@
+name: Install METIS_Pipeline through autotools
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    # Run every day at 2:00 UTC
+    - cron: "0 2 * * *"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  run:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo ./toolbox/install_dependencies_ubuntu.sh
+      - name: Run autotools
+        run: |
+          cd metisp
+          ./bootstrap
+          ./configure
+          make
+          make python
+          make install
+          make install-python
+      - name: Check recipes
+        # TODO: Actually check something here.
+        run: |
+          esorex --recipes

--- a/metisp/workflows/metis/metis_parameters.yaml
+++ b/metisp/workflows/metis/metis_parameters.yaml
@@ -1,0 +1,2 @@
+default_parameters:
+  is_default: yes


### PR DESCRIPTION
Tests whether the pipeline can be installed through autotools. Failed before #73 was included.

Not yet complete, as it doesn't actually check whether the recipes run etc, but at least it would prevent a regression of the kind fixed in #73.
