### PR TITLE
Minimum changes to fix ifu_rsrf recipe

### DIFF
--- a/metisp/pymetis/src/pymetis/classes/dataitems/dataitem.py
+++ b/metisp/pymetis/src/pymetis/classes/dataitems/dataitem.py
@@ -370,7 +370,8 @@ class ImageDataItem(DataItem, abstract=True):
                  header: cpl.core.PropertyList,
                  frame: cpl.ui.Frame):
         super().__init__(header, frame)
-        self.image: cpl.core.Image = cpl.core.Image.load(os.path.expandvars("$SOF_DATA/LINEARITY_2RG.fits"))
+        # TODO: hard-coded image loading to be removed
+        self.image: cpl.core.Image = cpl.core.Image.load(os.path.expandvars(f"$SOF_DATA/LINEARITY_{self._detector}.fits"))
 
     def save(self,
              recipe: 'PipelineRecipeImpl',

--- a/metisp/pymetis/src/pymetis/classes/dataitems/rsrf/rsrf.py
+++ b/metisp/pymetis/src/pymetis/classes/dataitems/rsrf/rsrf.py
@@ -19,7 +19,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 import cpl
 
-from pymetis.classes.dataitems.dataitem import ImageDataItem, DataItem
+from pymetis.classes.dataitems.dataitem import ImageDataItem, TableDataItem, DataItem
 from pymetis.classes.mixins import DetectorIfuMixin
 
 
@@ -31,10 +31,10 @@ class Rsrf(DataItem):
     _oca_keywords = {'PRO.CATG', 'DRS.IFU'}
 
 
-class RsrfIfu(DetectorIfuMixin, ImageDataItem):
+class RsrfIfu(DetectorIfuMixin, TableDataItem):
     _name_template = r'RSRF_IFU'
     _title_template = "RSRF IFU"
-    _description_template = "2D relative spectral response function"
+    _description_template = "1D relative spectral response function"
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
 

--- a/metisp/pymetis/src/pymetis/recipes/ifu/metis_ifu_rsrf.py
+++ b/metisp/pymetis/src/pymetis/recipes/ifu/metis_ifu_rsrf.py
@@ -40,7 +40,7 @@ from pymetis.classes.inputs import (BadPixMapInput, MasterDarkInput, RawInput, G
 from pymetis.classes.inputs import PersistenceInputSetMixin, LinearityInputSetMixin
 
 ma = np.ma
-EXT = 4  # TODO: update to read multi-extension files
+EXT = 4  # TODO: update to read multi-extension files and index by EXTNAME instead of integer
 
 
 class MetisIfuRsrfImpl(DarkImageProcessor):
@@ -207,8 +207,6 @@ class MetisIfuRsrfImpl(DarkImageProcessor):
 
         rsrf_table = cpl.core.Table(table)
 
-        product_background = IfuRsrfBackground(background_hdr, background_img)
-
         product_background = self.ProductRsrfBackground(background_hdr, background_img)
         product_master_flat_ifu = self.ProductMasterFlat(spec_flat_hdr, spec_flat_img)
         product_rsrf_ifu = self.ProductRsrfIfu(rsrf_hdr, rsrf_table)
@@ -279,6 +277,7 @@ def read_ifu_distortion_table(fits_file, ext: int = 1) -> list:
 
     Parameters:
     fits_file (str): Path to the FITS file containing the distortion table.
+    ext (int): Extension number to read from the FITS file.
 
     Returns:
     list: A list of tuples containing the x- and y-coordinates of the traces.


### PR DESCRIPTION
Small changes needed to the framework while testing `ifu_rsrf` recipe against the canned RSRF full-frame dataset.