### PR TITLE
IFU recipe chain updates

### DIFF
--- a/metisp/pymetis/src/pymetis/dataitems/ifu/ifu.py
+++ b/metisp/pymetis/src/pymetis/dataitems/ifu/ifu.py
@@ -99,7 +99,7 @@ class IfuCombined(IfuBase, abstract=True):
     _title_template = "spectral cube of science object"
     _description_template = "Spectral cube of a standard star, combining multiple exposures."
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _frame_group = cpl.ui.Frame.FrameGroup.PRODUCT
+    _frame_group = cpl.ui.Frame.FrameGroup.RAW
 
 
 class IfuStdCombined(TargetStdMixin, IfuCombined):

--- a/metisp/pymetis/src/pymetis/recipes/ifu/metis_ifu_calibrate.py
+++ b/metisp/pymetis/src/pymetis/recipes/ifu/metis_ifu_calibrate.py
@@ -41,7 +41,7 @@ class MetisIfuCalibrateImpl(MetisRecipeImpl):
     ProductSciCubeCalibrated = IfuScienceCubeCalibrated
 
     def process(self) -> set[DataItem]:
-        reduced = self.inputset.reduced.load_data(extension='PRIMARY')
+        reduced = self.inputset.reduced.load_data(extension='DET1.DATA')
         self.inputset.reduced.use()
 
         primary_header = create_dummy_header()

--- a/metisp/pymetis/src/pymetis/recipes/ifu/metis_ifu_reduce.py
+++ b/metisp/pymetis/src/pymetis/recipes/ifu/metis_ifu_reduce.py
@@ -56,6 +56,8 @@ class MetisIfuReduceImpl(DarkImageProcessor):
     ProductBackground = IfuBackground
     ProductReducedCube = IfuReducedCube
     ProductCombined = IfuCombined
+    # FixMe: override frame group when dataitem used as product
+    ProductCombined._frame_group = cpl.ui.Frame.FrameGroup.PRODUCT
 
     def _process_single_detector(self, detector: Literal[1, 2, 3, 4]) -> dict[str, Hdu]:
         """

--- a/metisp/pymetis/src/pymetis/recipes/ifu/metis_ifu_telluric.py
+++ b/metisp/pymetis/src/pymetis/recipes/ifu/metis_ifu_telluric.py
@@ -22,9 +22,11 @@ from pymetis.classes.dataitems import DataItem
 from pymetis.classes.dataitems.hdu import Hdu
 from pymetis.dataitems.common import FluxCalTable, IfuTelluric
 from pymetis.dataitems.ifu.ifu import IfuReduced1d, IfuCombined
+from pymetis.dataitems.ifu.raw import IfuRaw
 from pymetis.classes.recipes import MetisRecipe, MetisRecipeImpl
-from pymetis.classes.inputs import SinglePipelineInput, PipelineInputSet
+from pymetis.classes.inputs import SinglePipelineInput, PipelineInputSet, RawInput, MasterDarkInput
 from pymetis.classes.inputs import FluxstdCatalogInput, LsfKernelInput, AtmProfileInput
+from pymetis.classes.prefab.rawimage import RawImageProcessor
 from pymetis.utils.dummy import create_dummy_header, create_dummy_image, create_dummy_table
 
 
@@ -48,6 +50,10 @@ class MetisIfuTelluricImpl(MetisRecipeImpl):
         #     _group = cpl.ui.Frame.FrameGroup.CALIB
         #     _title: str = "uncorrected mf input spectrum"
         #     _description: str = "Uncorrected MF input spectrum."
+
+        # FixMe: using raw input to avoid empty frameset on product save issue
+        class RawInput(RawInput):
+            Item = IfuRaw
 
         class CombinedInput(SinglePipelineInput):
             Item = IfuCombined
@@ -106,7 +112,9 @@ class MetisIfuTelluricImpl(MetisRecipeImpl):
         image = create_dummy_image()
         table = create_dummy_table()
 
-        combined = self.inputset.combined.load_data('IMAGE')
+        # FixMe: using raw input to avoid empty frameset on product save issue
+        combined = self.inputset.raw.load_data('DET1.DATA')
+        self.inputset.raw.use()
 
         product_telluric_transmission = self.ProductTelluricTransmission(
             primary_header,

--- a/metisp/workflows/metis/metis_ifu_wkf.py
+++ b/metisp/workflows/metis/metis_ifu_wkf.py
@@ -85,7 +85,9 @@ ifu_sci_reduce_task = (task("metis_ifu_sci_reduce")
 
 ifu_sci_telluric_task = (task("metis_ifu_sci_telluric")
                 .with_recipe("metis_ifu_telluric")
-                .with_main_input(ifu_sci_reduce_task)
+                # FixMe: using raw input to avoid empty frameset on product save issue
+                .with_main_input(ifu_sci_raw)
+                .with_associated_input(ifu_sci_reduce_task)
                 .with_associated_input(fluxstd_catalog)
                 .with_associated_input(lsf_kernel)
                 .with_associated_input(atm_profile)
@@ -95,7 +97,9 @@ ifu_sci_telluric_task = (task("metis_ifu_sci_telluric")
 
 ifu_std_telluric_task = (task("metis_ifu_std_telluric")
                  .with_recipe("metis_ifu_telluric")
-                 .with_main_input(ifu_std_reduce_task)
+                # FixMe: using raw input to avoid empty frameset on product save issue
+                 .with_main_input(ifu_std_raw)
+                 .with_associated_input(ifu_std_reduce_task)
                  .with_associated_input(fluxstd_catalog)
                  .with_associated_input(lsf_kernel)
                  .with_associated_input(atm_profile)


### PR DESCRIPTION
Changes to allow IFU workflow to run end-to-end.

NOTE: As a temporary workaround I needed to artificially add an `ifu_sci/std_raw` frame as main input for the `metis_ifu_sci/std/telluric` tasks to avoid an empty recipe frameset error when saving the telluric products. Just changing the `ifu_sci/std_combined` input dataitem definition to RAW does not solve it.