### PR TITLE
Make pipeline Python 3.11 compatible again by changing some f-strings.

### DIFF
--- a/metisp/pymetis/src/pymetis/classes/dataitems/dataitem.py
+++ b/metisp/pymetis/src/pymetis/classes/dataitems/dataitem.py
@@ -402,7 +402,7 @@ class DataItem(Parametrizable, ABC):
         """
         # ToDo determine how this should be really formed: timestamp, hash, combination?
         # ToDo Hugo says there is a 56 char limit for file names
-        return f"{self.name()}_{self._created_at.strftime("%Y-%m-%dT%H-%M-%S-%f")}.fits" \
+        return f"{self.name()}_{self._created_at.strftime('%Y-%m-%dT%H-%M-%S-%f')}.fits" \
             if override is None else override
 
     def add_properties(self) -> None:

--- a/metisp/pymetis/src/pymetis/classes/recipes/impl.py
+++ b/metisp/pymetis/src/pymetis/classes/recipes/impl.py
@@ -65,7 +65,7 @@ class MetisRecipeImpl(ABC):
         self.import_settings(settings)                  # Import and process the provided settings dict
         self.inputset.print_debug()
         Msg.debug(self.__class__.__qualname__,
-                  f"{"-" * 40} Recipe initialization complete {"-" * 40}")
+                  f"{'-' * 40} Recipe initialization complete {'-' * 40}")
 
     @classmethod
     def specialize(cls, **parameters) -> None:

--- a/metisp/pymetis/src/pymetis/utils/format.py
+++ b/metisp/pymetis/src/pymetis/utils/format.py
@@ -25,7 +25,7 @@ class FormatPlaceholder:
         self.key = key
 
     def __format__(self, spec):
-        value = f'{self.key}{f':{spec}' if spec else ''}'
+        value = f"{self.key}{f':{spec}' if spec else ''}"
         return f"{{{value}}}"
 
 


### PR DESCRIPTION
These f-string quotes are not important enough to sacrifice Python 3.11 compatibility for.