### PR TITLE
Use all obligatory raws

### DIFF
--- a/metisp/pymetis/src/pymetis/recipes/metis_det_lingain.py
+++ b/metisp/pymetis/src/pymetis/recipes/metis_det_lingain.py
@@ -88,6 +88,7 @@ class MetisDetLinGainImpl(RawImageProcessor, ABC):
     def process(self) -> set[DataItem]:
         Msg.info(self.__class__.__qualname__, f"Loading raw data")
         self.inputset.raw.load_structure()
+        self.inputset.wcu_off.load_structure()
 
         # Flat field preparation: subtract bias and normalize it to median 1
         # Msg.info(self.name, "Preparing flat field")


### PR DESCRIPTION
`metis_det_lingain` has `wcu_off` as mandatory input. Therefore it must also be used, otherwise the `wcu_off` will not be encoded in the data lineage. Without this, the created `LINEARITY_2RG` file cannot be reprocessed, because it is unknown what the input `wcu_off` frame was.