### PR TITLE
Temp fix for type checking issue

### DIFF
--- a/metisp/pymetis/src/pymetis/classes/qc/parameter.py
+++ b/metisp/pymetis/src/pymetis/classes/qc/parameter.py
@@ -18,6 +18,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
 from typing import Optional, Any
+from cpl.core import Msg
 
 import cpl
 
@@ -32,8 +33,9 @@ class QcParameter(Parametrizable):
     _comment: Optional[str] = None
 
     def __init__(self, value: Any):
-        assert isinstance(value, self._type), \
-            f"{self.__class__.__qualname__} expected a {self._type} value, but got {value} ({type(value)}) instead"
+
+        #assert isinstance(value, self._type), \
+        #    f"{self.__class__.__qualname__} expected a {self._type} value, but got {value} ({type(value)}) instead"
         self._value = value
 
     @property
@@ -50,4 +52,5 @@ class QcParameter(Parametrizable):
         return f"    {cls._name:<23s} {f'{cls._type}'[5:]:<14s} {cls._description}"
 
     def as_property(self) -> cpl.core.Property:
+        Msg.info(self.__class__.__qualname__, f"PARAM {self._name} {self._type}, self.")
         return cpl.core.Property(self._name, self._type, self.value, self._description)


### PR DESCRIPTION
Commented out the isinstance typechecking in paramter.py for two reasons

1) isinstance expects a python type, and crashes when passed a cpl.core.Type

2) the value of the QC paramter will typically float or int, as that's what's passed bakc from the various mean/std type image methods. It's cast to a cpl type in the cpl.core.Property call later in the routine.

I'm not sure how to test datatypes in pycpl (although there is a error code for it).

So far, commenting that out has lets the lmImg sequence run to completion, although I don't find the actual QC parameters in the DARK header. 