### PR TITLE
Fix instrument AttributeError

### DIFF
--- a/metisp/pymetis/src/pymetis/instruments/metis/recipes/metis_det_dark.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/recipes/metis_det_dark.py
@@ -42,6 +42,7 @@ from pymetis.instruments.metis.dataitems.masterdark.masterdark import MasterDark
 from pymetis.instruments.metis.dataitems.masterdark.raw import DarkRaw
 from pymetis.instruments.metis.inputs import (RawInput, BadPixMapInput, PersistenceMapInput,
                                               LinearityInput, GainMapInput, OptionalInputMixin)
+from pymetis.instruments.metis.recipes.base import MetisRecipeImpl
 from pymetis.instruments.metis.recipes.prefab import RawImageProcessor
 
 from pymetis.instruments.metis.qc.dark import (DarkMean, DarkMedian, DarkRms, DarkNColdpix, DarkNHotpix, DarkNBadpix,
@@ -49,7 +50,7 @@ from pymetis.instruments.metis.qc.dark import (DarkMean, DarkMedian, DarkRms, Da
                                                DarkMedianRms, DarkMedianMin, DarkMedianMax)
 
 
-class MetisDetDarkImpl(PersistenceCorrectionMixin, RawImageProcessor, ABC):
+class MetisDetDarkImpl(PersistenceCorrectionMixin, RawImageProcessor, MetisRecipeImpl):
     """
     Implementation class for the `metis_det_dark` recipe.
     """

--- a/metisp/pymetis/src/pymetis/instruments/metis/recipes/metis_det_lingain.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/recipes/metis_det_lingain.py
@@ -37,12 +37,13 @@ from pymetis.instruments.metis.dataitems.linearity.linearity import LinearityMap
 from pymetis.instruments.metis.dataitems.linearity.raw import LinearityRaw
 from pymetis.instruments.metis.inputs import RawInput, BadPixMapInput, OptionalInputMixin
 from pymetis.instruments.metis.inputs.common import WcuOffInput
+from pymetis.instruments.metis.recipes.base import MetisRecipeImpl
 from pymetis.instruments.metis.recipes.prefab import RawImageProcessor
 from pymetis.instruments.metis.qc.lingain import (LinGainMean, LinGainRms, LinNumBadpix, LinMinFlux, LinMaxFlux,
                                                   GainLin, GainCoeff)
 
 
-class MetisDetLinGainImpl(RawImageProcessor, ABC):
+class MetisDetLinGainImpl(RawImageProcessor, MetisRecipeImpl):
     class InputSet(RawImageProcessor.InputSet):
         class RawInput(RawInput):
             Item = LinearityRaw


### PR DESCRIPTION
Currently the Lingain and Dark recipes fail because there is an import missing in their corresponding data item classes.
This results in the following error: `AttributeError: 'MetisDetLinGainImpl' object has no attribute 'instrument'`
This PR fixes the issue by adding the import.