### PR TITLE
Added ImageLists as possible output.

### DIFF
--- a/metisp/pymetis/src/pymetis/engine/dataitems/dataitem.py
+++ b/metisp/pymetis/src/pymetis/engine/dataitems/dataitem.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Optional, Generator, Self, final, Union, ClassVar
 
 import cpl
-from cpl.core import Msg, Image, Table, PropertyList as CplPropertyList
+from cpl.core import Msg, Image, Table, ImageList, PropertyList as CplPropertyList
 
 import pymetis
 from .hdu import Hdu
@@ -61,7 +61,7 @@ class DataItem(ParametrizableItem):
 
     # HDU schema: a dict of types or None
     # By default, only the primary header is present
-    _schema: ClassVar[dict[str, Union[None, type[Image], type[Table]]]] = {'PRIMARY': None}
+    _schema: ClassVar[dict[str, Union[None, type[Image], type[Table], type[ImageList]]]] = {'PRIMARY': None}
     # For instance
     # >>> _schema = {
     # >>>     'PRIMARY': None,
@@ -76,7 +76,7 @@ class DataItem(ParametrizableItem):
 
     @classmethod
     @final
-    def schema(cls) -> dict[str, Union[None, type[Image], type[Table]]]:
+    def schema(cls) -> dict[str, Union[None, type[Image], type[Table], type[ImageList]]]:
         return cls._schema
 
     @classmethod

--- a/metisp/pymetis/src/pymetis/engine/dataitems/hdu.py
+++ b/metisp/pymetis/src/pymetis/engine/dataitems/hdu.py
@@ -23,6 +23,7 @@ from typing import Optional
 import cpl
 from cpl.core import (Image as CplImage,
                       Table as CplTable,
+                      ImageList as CplImageList,
                       PropertyList as CplPropertyList, Msg)
 
 from pymetis.engine.core.dummy import make_cpl_property
@@ -34,10 +35,10 @@ class Hdu:
     """
     def __init__(self,
                  header: CplPropertyList,
-                 data: Optional[CplImage | CplTable],
+                 data: Optional[CplImage | CplTable | CplImageList],
                  *,
                  name: Optional[str] = None, # FixMe this should not really be optional for creation (but yes for loading)
-                 klass: Optional[type[CplImage | CplTable]] = None,
+                 klass: Optional[type[CplImage | CplTable | CplImageList]] = None,
                  extno: Optional[int] = 0):
         """
 
@@ -76,6 +77,8 @@ class Hdu:
             # Here the signature is (primary_header, header, filename, mode) for whatever reason...
             # FixMe What if there are multiple tables? Is primary header overwritten or what?
             self.data.save(self.header, self.header, filename, cpl.core.io.EXTEND)
+        elif self.klass == CplImageList:
+            self.data.save(filename, self.header, cpl.core.io.EXTEND)
 
 
 class MetisImage:


### PR DESCRIPTION
Added some code to handle saving ImageLists so we can write 3D imagelists to fits files. The loading part is not implemented yet and needs Martin. I am also not entirely sure everything is as it should be, but for a demo of calculating detlin and saving 3D linearity maps this is a set of changes that works.

I also have files with changes to the GainMap and LinearityMap dataitems to use the new ImageList but these will be part of another PR.