### PR TITLE
mb/metaclass

### DIFF
--- a/metisp/pymetis/src/pymetis/engine/core/functions/frameset.py
+++ b/metisp/pymetis/src/pymetis/engine/core/functions/frameset.py
@@ -53,6 +53,8 @@ def represent_frameset(frameset: cpl.ui.FrameSet) -> dict[str, str]:
 def from_filenames(frames: dict[str, str]) -> cpl.ui.FrameSet:
     """
     Create a CPL FrameSet from a mapping `{filename: tag}`
+
+    FixMe: This is not all-powerful! You cannot reuse the same file with multiple tags unlike with `from_tags`!
     """
     return cpl.ui.FrameSet([
         cpl.ui.Frame(os.path.expandvars(frame),

--- a/metisp/pymetis/src/pymetis/engine/core/functions/frameset.py
+++ b/metisp/pymetis/src/pymetis/engine/core/functions/frameset.py
@@ -54,7 +54,9 @@ def from_filenames(frames: dict[str, str]) -> cpl.ui.FrameSet:
     """
     Create a CPL FrameSet from a mapping `{filename: tag}`
 
-    FixMe: This is not all-powerful! You cannot reuse the same file with multiple tags unlike with `from_tags`!
+    Warning: This is not all-powerful! Python will not allow you to reuse
+    the same file with multiple tags unlike with `from_tags`!
+    Consider using `from_tags` if possible.
     """
     return cpl.ui.FrameSet([
         cpl.ui.Frame(os.path.expandvars(frame),
@@ -67,7 +69,9 @@ def from_filenames(frames: dict[str, str]) -> cpl.ui.FrameSet:
 
 def from_tags(**tagged: dict[str, list[str]]) -> cpl.ui.FrameSet:
     """
-    Create a CPL FrameSet from kwargs `{tag: list[filename]}`
+    Create a CPL FrameSet from kwargs in format `{tag: list[filename]}`.
+    This is also used as an internal representation in recipes.
+    Note that you can reuse the same file with different tags.
     """
     return cpl.ui.FrameSet([
         cpl.ui.Frame(os.path.expandvars(frame),

--- a/metisp/pymetis/src/pymetis/engine/core/parametrizable.py
+++ b/metisp/pymetis/src/pymetis/engine/core/parametrizable.py
@@ -81,6 +81,7 @@ class Parametrizable(ABC):
         merged.update(kwargs)
 
         cls._tag_parameters = merged
+        super().__init_subclass__(**kwargs)
 
 
 class ParametrizableContainer(Parametrizable, ABC):
@@ -159,7 +160,7 @@ class ParametrizableContainer(Parametrizable, ABC):
                           f" - {item.__qualname__} ({item.name()}) => {new_class.__qualname__} ({new_class.name()})")
 
             # Replace the corresponding attribute with the new class
-            cls.__class__.__setattr__(cls, name, new_class)
+            setattr(cls, name, new_class)
 
 
 class ParametrizableItem(Parametrizable, ABC):
@@ -188,7 +189,6 @@ class ParametrizableItem(Parametrizable, ABC):
             If abstract, the class is not expected to be instantiated and will raise an exception if this is attempted.
         """
         super().__init_subclass__(**kwargs)
-
         cls._abstract = abstract
         if cls.name() in cls._registry:
             # If the class is already registered, warn about it and do nothing.
@@ -240,7 +240,7 @@ class ParametrizableItem(Parametrizable, ABC):
         but can be overridden to build the description from other data, such as band or target.
         """
         assert cls._description_template is not None, \
-            f"{cls.__name__} description template is None"
+            f"{cls.__qualname__} description template is None"
         return partial_format(cls._description_template, **cls.tag_parameters())
 
 

--- a/metisp/pymetis/src/pymetis/engine/core/parametrizable.py
+++ b/metisp/pymetis/src/pymetis/engine/core/parametrizable.py
@@ -36,10 +36,10 @@ class ParametrizableMeta(ABCMeta):
     """
 
     def __new__(mcs, name, bases, namespace, *, abstract=False, **kwargs):
-        cls = super().__new__(mcs, name, bases, namespace)  # don't forward kwargs to type
+        cls = super().__new__(mcs, name, bases, namespace)
         cls._abstract = abstract
 
-        # Merge _tag_parameters from the MRO, then layer kwargs on top
+        # Merge tag parameters from MRO + class kwargs
         merged = {}
         for base in reversed(cls.__mro__):
             params = base.__dict__.get("_tag_parameters")
@@ -48,36 +48,43 @@ class ParametrizableMeta(ABCMeta):
         merged.update(kwargs)
         cls._tag_parameters = merged
 
-        if abstract:
-            return cls
+        # Resolve template against known parameters
+        template = namespace.get("_name_template")
+        if template is None:
+            template = next(
+                (b.__dict__["_name_template"] for b in cls.__mro__[1:]
+                 if b.__dict__.get("_name_template") is not None),
+                None,
+            )
+        if template is not None and merged:
+            cls._name_template = partial_format(template, **merged)
 
-        # Find the nearest root (a class with its own _registry in __dict__)
+        if not abstract:
+            cls._register()
+
+        return cls
+
+    def __init__(cls, name, bases, namespace, *, abstract=False, **kwargs):
+        super().__init__(name, bases, namespace)
+
+    def _register(cls) -> None:
+        """Register cls under its current _name_template in the nearest _registry up the MRO."""
+        key = getattr(cls, "_name_template", None)
+        if key is None:
+            return
         registry = next(
-            (base.__dict__["_registry"]
-             for base in cls.__mro__
-             if "_registry" in base.__dict__),
+            (b.__dict__["_registry"] for b in cls.__mro__ if "_registry" in b.__dict__),
             None,
         )
         if registry is None:
-            return cls  # cls is itself a root, or no root yet
-
-        # Skip if name() can't be computed or still has placeholders
-        try:
-            tag = cls.name()
-        except (AttributeError, AssertionError):
-            return cls
-        if tag is None or "{" in tag:
-            return cls
-
-        if tag in registry:
-            Msg.debug(cls.__qualname__, f"{tag} already registered, skipping")
+            return
+        if key in registry:
+            if registry[key] is not cls:
+                Msg.debug(cls.__qualname__, f"{key} already registered to {registry[key].__qualname__}, skipping")
         else:
-            registry[tag] = cls
-            Msg.debug(cls.__qualname__, f"New {cls.__name__} registered as {tag}")
-        return cls
+            registry[key] = cls
 
-    # Class-level helpers — accessed as DataItem.find(...), no @classmethod needed
-    def find(cls, key):
+    def find(cls, key: str):
         for base in cls.__mro__:
             reg = base.__dict__.get("_registry")
             if reg is not None:
@@ -135,9 +142,11 @@ class ParametrizableItem(Parametrizable, abstract=True):
     @classmethod
     def specialize(cls, **parameters: str) -> str:
         """
-        Specialize the data item's name template with given parameters
+        Specialize this class for parameters
         """
+        cls._tag_parameters = cls._tag_parameters | parameters
         cls._name_template = partial_format(cls._name_template, **parameters)
+        type(cls)._register(cls)  # call the metaclass method
         return cls._name_template
 
     @classmethod
@@ -197,13 +206,12 @@ class ParametrizableContainer(Parametrizable, ABC):
             new_class.specialize(**(item_class.tag_parameters() | parameters))
 
             # Re-attempt registration now that the template may be fully resolved
-            if "{" not in new_class._name_template:
-                registry = next(
-                    (b.__dict__["_registry"] for b in new_class.__mro__ if "_registry" in b.__dict__),
-                    None,
-                )
-                if registry is not None and new_class._name_template not in registry:
-                    registry[new_class._name_template] = new_class
+            registry = next(
+                (b.__dict__["_registry"] for b in new_class.__mro__ if "_registry" in b.__dict__),
+                None,
+            )
+            if registry is not None and new_class._name_template not in registry:
+                registry[new_class._name_template] = new_class
 
             if (klass := cls.Meta._T.find(new_class._name_template)) is None:
                 setattr(cls, name, new_class)
@@ -241,22 +249,6 @@ class ParametrizableContainer(Parametrizable, ABC):
                     f"tag '{tag}' is not registered. "
                     f"Known tags matching: {cls.Meta._T._registry}"
                 )
-            setattr(cls, name, new_class)
-
-        return
-
-        for name, item in cls.list_classes():
-            # Merge the predefined parameters with the new ones
-            expanded_parameters = item.tag_parameters() | parameters
-
-            # Try to find a promoted class in the registry
-            if (new_class := cls.Meta._T.find(tag := item.specialize(**expanded_parameters))) is None:
-                raise TypeError(f"Could not promote class {item}: {tag} is not a registered tag")
-            else:
-                Msg.debug(cls.__qualname__,
-                          f" - {item.__qualname__} ({item.name()}) => {new_class.__qualname__} ({new_class.name()})")
-
-            # Replace the corresponding attribute with the new class
             setattr(cls, name, new_class)
 
 

--- a/metisp/pymetis/src/pymetis/engine/core/parametrizable.py
+++ b/metisp/pymetis/src/pymetis/engine/core/parametrizable.py
@@ -17,7 +17,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 """
 import inspect
-from abc import ABC
+from abc import ABC, ABCMeta
 from typing import ClassVar, Self, Optional, final, Any
 
 from cpl.core import Msg
@@ -25,7 +25,72 @@ from cpl.core import Msg
 from pymetis.engine.core.format import partial_format
 
 
-class Parametrizable(ABC):
+class ParametrizableMeta(ABCMeta):
+    """
+    Metaclass for the Parametrizable hierarchy.
+
+    Handles:
+      - tag parameter merging across the MRO
+      - auto-registration of concrete subclasses into their root's _registry
+      - skipping abstract classes and partially-specialized templates
+    """
+
+    def __new__(mcs, name, bases, namespace, *, abstract=False, **kwargs):
+        cls = super().__new__(mcs, name, bases, namespace)  # don't forward kwargs to type
+        cls._abstract = abstract
+
+        # Merge _tag_parameters from the MRO, then layer kwargs on top
+        merged = {}
+        for base in reversed(cls.__mro__):
+            params = base.__dict__.get("_tag_parameters")
+            if isinstance(params, dict):
+                merged.update(params)
+        merged.update(kwargs)
+        cls._tag_parameters = merged
+
+        if abstract:
+            return cls
+
+        # Find the nearest root (a class with its own _registry in __dict__)
+        registry = next(
+            (base.__dict__["_registry"]
+             for base in cls.__mro__
+             if "_registry" in base.__dict__),
+            None,
+        )
+        if registry is None:
+            return cls  # cls is itself a root, or no root yet
+
+        # Skip if name() can't be computed or still has placeholders
+        try:
+            tag = cls.name()
+        except (AttributeError, AssertionError):
+            return cls
+        if tag is None or "{" in tag:
+            return cls
+
+        if tag in registry:
+            Msg.debug(cls.__qualname__, f"{tag} already registered, skipping")
+        else:
+            registry[tag] = cls
+        return cls
+
+    # Class-level helpers — accessed as DataItem.find(...), no @classmethod needed
+    def find(cls, key):
+        for base in cls.__mro__:
+            reg = base.__dict__.get("_registry")
+            if reg is not None:
+                return reg.get(key)
+        return None
+
+    def list_classes(cls):
+        return [
+            (n, k) for n, k in inspect.getmembers(cls, inspect.isclass)
+            if isinstance(k, ParametrizableMeta) and k is not cls
+        ]
+
+
+class Parametrizable(ABC, metaclass=ParametrizableMeta):
     """
     Abstract base class for all types parametrizable by custom tags
     (tiny pieces of data, such as short strings or integers).
@@ -55,33 +120,21 @@ class Parametrizable(ABC):
     Other parameters might be useful for different pipelines.
     Any strings or types convertible to strings (!s) may be used.
     """
-
-    # Tag parameters defined for this class.
     _tag_parameters: ClassVar[dict[str, Any]] = {}
 
     @classmethod
-    def tag_parameters(cls) -> dict[str, Any]:
-        """
-        Return the tag parameters for this class.
-        By default, there are none, but mixins may add their own.
-        """
+    def tag_parameters(cls):
         return cls._tag_parameters
 
-    def __init_subclass__(cls, **kwargs):
-        """
-        Merge tag parameters from all base classes.
-        """
-        merged = {}
-        # ToDo: Does this really do what we want it to do? What is the desired order of preference?
-        for base in reversed(cls.__mro__):
-            params = base.__dict__.get('_tag_parameters')
-            if isinstance(params, dict):
-                merged.update(params)
 
-        merged.update(kwargs)
+class ParametrizableItem(Parametrizable, abstract=True):
+    _name_template: ClassVar[str] = None
+    _description_template: ClassVar[Optional[str]] = None
 
-        cls._tag_parameters = merged
-        super().__init_subclass__()
+    @classmethod
+    def name(cls) -> str:
+        assert cls._name_template is not None
+        return partial_format(cls._name_template, **cls.tag_parameters())
 
 
 class ParametrizableContainer(Parametrizable, ABC):
@@ -97,11 +150,6 @@ class ParametrizableContainer(Parametrizable, ABC):
         _T: the expected type of the inner items.
         """
         _T: ClassVar[type['ParametrizableItem']] = None
-
-    @classmethod
-    def list_classes(cls):
-        """ List all available inner items """
-        return inspect.getmembers(cls, lambda x: inspect.isclass(x) and issubclass(x, cls.Meta._T))
 
     @classmethod
     def list_descriptions(cls) -> str:
@@ -149,6 +197,22 @@ class ParametrizableContainer(Parametrizable, ABC):
                  f"Promoting {cls.__qualname__} with {parameters}")
 
         for name, item in cls.list_classes():
+            # Compute the target tag without mutating `item`
+            tag = partial_format(item._name_template,
+                                 **(item.tag_parameters() | parameters))
+
+            new_class = cls.Meta._T.find(tag)
+            if new_class is None:
+                raise TypeError(
+                    f"Could not promote {item.__qualname__}: "
+                    f"tag '{tag}' is not registered. "
+                    f"Known tags matching: {[k for k in cls.Meta._T._registry if k.startswith(tag.split('{')[0])]}"
+                )
+            setattr(cls, name, new_class)
+
+        return
+
+        for name, item in cls.list_classes():
             # Merge the predefined parameters with the new ones
             expanded_parameters = item.tag_parameters() | parameters
 
@@ -175,45 +239,6 @@ class ParametrizableItem(Parametrizable, ABC):
 
     # Class registry: all derived classes are automatically registered here (unless declared abstract)
     _registry: ClassVar[dict[str, type[Self]]] = {}
-
-    def __init_subclass__(cls,
-                          *,
-                          abstract: bool = False,
-                          **kwargs):
-        """
-        Register every subclass of ParametrizableItem in a class-global registry, based on its tag parameters.
-
-        Parameters
-        ----------
-        abstract: bool
-            If abstract, the class is not expected to be instantiated and will raise an exception if this is attempted.
-        """
-        super().__init_subclass__(**kwargs)
-        cls._abstract = abstract
-        if cls.name() in cls._registry:
-            # If the class is already registered, warn about it and do nothing.
-            Msg.debug(cls.__qualname__,
-                      f"A {cls.__qualname__} with tag {cls.name()} is already registered, "
-                      f"skipping: {cls._registry[cls.name()].__qualname__}")
-        else:
-            # Otherwise add the class to the global registry
-            Msg.debug(cls.__qualname__,
-                      f"Registered a new class {cls.name()}: {cls}")
-            cls._registry[cls.name()] = cls
-
-    @classmethod
-    @final
-    def find(cls, key: str) -> Optional[type[Self]]:
-        """
-        Try to retrieve the ParametrizableItem subclass with tag ``key`` from the global registry.
-
-        If not found, return ``None`` instead (and leave it to the caller to raise an exception if this is not desired).
-        # ToDo: Maybe we should raise an exception here instead and let the caller handle it?
-        """
-        if key in cls._registry:
-            return cls._registry[key]
-        else:
-            return None
 
     @classmethod
     def specialize(cls, **parameters: str) -> str:

--- a/metisp/pymetis/src/pymetis/engine/core/parametrizable.py
+++ b/metisp/pymetis/src/pymetis/engine/core/parametrizable.py
@@ -73,6 +73,7 @@ class ParametrizableMeta(ABCMeta):
             Msg.debug(cls.__qualname__, f"{tag} already registered, skipping")
         else:
             registry[tag] = cls
+            Msg.debug(cls.__qualname__, f"New {cls.__name__} registered as {tag}")
         return cls
 
     # Class-level helpers — accessed as DataItem.find(...), no @classmethod needed
@@ -132,9 +133,32 @@ class ParametrizableItem(Parametrizable, abstract=True):
     _description_template: ClassVar[Optional[str]] = None
 
     @classmethod
+    def specialize(cls, **parameters: str) -> str:
+        """
+        Specialize the data item's name template with given parameters
+        """
+        cls._name_template = partial_format(cls._name_template, **parameters)
+        return cls._name_template
+
+    @classmethod
     def name(cls) -> str:
-        assert cls._name_template is not None
+        """
+        Return the machine-oriented name (tag) of the data item as defined in the DRLD, e.g. "DETLIN_2RG_RAW".
+        """
+        assert cls._name_template is not None, \
+            f"{cls.__qualname__} name template is None"
         return partial_format(cls._name_template, **cls.tag_parameters())
+
+    @classmethod
+    def description(cls) -> str:
+        """
+        Return the human-readable description of the item.
+        By default, this just returns the protected internal attribute,
+        but can be overridden to build the description from other data, such as band or target.
+        """
+        assert cls._description_template is not None, \
+            f"{cls.__qualname__} description template is None"
+        return partial_format(cls._description_template, **cls.tag_parameters())
 
 
 class ParametrizableContainer(Parametrizable, ABC):
@@ -171,12 +195,13 @@ class ParametrizableContainer(Parametrizable, ABC):
             # Copy the entire type so that we do not mess up the original one
             new_class: cls.Meta._T = type(item_class.__name__, item_class.__bases__, dict(item_class.__dict__))
             new_class.specialize(**(item_class.tag_parameters() | parameters))
+            Msg.debug(cls.__qualname__, f"{item_class.__name__} => {item_class.__bases__} {new_class.name()}")
 
             if (klass := cls.Meta._T.find(new_class._name_template)) is None:
                 setattr(cls, name, new_class)
                 Msg.debug(cls.__qualname__,
                           f"Cannot specialize {old_class.__qualname__} ({old_class.name()}) with {parameters}, "
-                          f"had to create a new class {new_class.__qualname__}")
+                          f"had to create a new class {new_class.__qualname__} ({new_class.name()})")
             else:
                 setattr(cls, name, klass)
                 Msg.debug(cls.__qualname__,
@@ -206,7 +231,7 @@ class ParametrizableContainer(Parametrizable, ABC):
                 raise TypeError(
                     f"Could not promote {item.__qualname__}: "
                     f"tag '{tag}' is not registered. "
-                    f"Known tags matching: {[k for k in cls.Meta._T._registry if k.startswith(tag.split('{')[0])]}"
+                    f"Known tags matching: {cls.Meta._T._registry}"
                 )
             setattr(cls, name, new_class)
 
@@ -225,48 +250,6 @@ class ParametrizableContainer(Parametrizable, ABC):
 
             # Replace the corresponding attribute with the new class
             setattr(cls, name, new_class)
-
-
-class ParametrizableItem(Parametrizable, ABC):
-    """
-    Abstract base class for all items parametrizable by tags, such as data items and QC parameters.
-    """
-
-    # Name of this item (machine-oriented)
-    _name_template: ClassVar[str] = None
-    # Description of this item (human-readable)
-    _description_template: ClassVar[str] = None
-
-    # Class registry: all derived classes are automatically registered here (unless declared abstract)
-    _registry: ClassVar[dict[str, type[Self]]] = {}
-
-    @classmethod
-    def specialize(cls, **parameters: str) -> str:
-        """
-        Specialize the data item's name template with given parameters
-        """
-        cls._name_template = partial_format(cls._name_template, **parameters)
-        return cls._name_template
-
-    @classmethod
-    def name(cls) -> str:
-        """
-        Return the machine-oriented name (tag) of the data item as defined in the DRLD, e.g. "DETLIN_2RG_RAW".
-        """
-        assert cls._name_template is not None, \
-            f"{cls.__qualname__} name template is None"
-        return partial_format(cls._name_template, **cls.tag_parameters())
-
-    @classmethod
-    def description(cls) -> str:
-        """
-        Return the human-readable description of the item.
-        By default, this just returns the protected internal attribute,
-        but can be overridden to build the description from other data, such as band or target.
-        """
-        assert cls._description_template is not None, \
-            f"{cls.__qualname__} description template is None"
-        return partial_format(cls._description_template, **cls.tag_parameters())
 
 
 class KeywordMixin(Parametrizable, ABC):

--- a/metisp/pymetis/src/pymetis/engine/core/parametrizable.py
+++ b/metisp/pymetis/src/pymetis/engine/core/parametrizable.py
@@ -81,7 +81,7 @@ class Parametrizable(ABC):
         merged.update(kwargs)
 
         cls._tag_parameters = merged
-        super().__init_subclass__(**kwargs)
+        super().__init_subclass__()
 
 
 class ParametrizableContainer(Parametrizable, ABC):

--- a/metisp/pymetis/src/pymetis/engine/core/parametrizable.py
+++ b/metisp/pymetis/src/pymetis/engine/core/parametrizable.py
@@ -32,7 +32,7 @@ class ParametrizableMeta(ABCMeta):
     Handles:
       - tag parameter merging across the MRO
       - auto-registration of concrete subclasses into their root's _registry
-      - skipping abstract classes and partially-specialized templates
+      - skipping abstract classes
     """
 
     def __new__(mcs, name, bases, namespace, *, abstract=False, **kwargs):
@@ -69,8 +69,7 @@ class ParametrizableMeta(ABCMeta):
 
     def _register(cls) -> None:
         """Register cls under its current _name_template in the nearest _registry up the MRO."""
-        key = getattr(cls, "_name_template", None)
-        if key is None:
+        if (key := getattr(cls, "_name_template", None)) is None:
             return
         registry = next(
             (b.__dict__["_registry"] for b in cls.__mro__ if "_registry" in b.__dict__),
@@ -78,20 +77,19 @@ class ParametrizableMeta(ABCMeta):
         )
         if registry is None:
             return
-        if key in registry:
+        elif key in registry:
             if registry[key] is not cls:
-                Msg.debug(cls.__qualname__, f"{key} already registered to {registry[key].__qualname__}, skipping")
+                Msg.warning(cls.__qualname__, f"{key} is already registered to {registry[key].__qualname__}, skipping")
         else:
             registry[key] = cls
 
-    def find(cls, key: str):
+    def find(cls, key: str) -> Optional[type]:
         for base in cls.__mro__:
-            reg = base.__dict__.get("_registry")
-            if reg is not None:
+            if (reg := base.__dict__.get("_registry")) is not None:
                 return reg.get(key)
         return None
 
-    def list_classes(cls):
+    def list_classes(cls) -> list[tuple[str, type]]:
         return [
             (n, k) for n, k in inspect.getmembers(cls, inspect.isclass)
             if isinstance(k, ParametrizableMeta) and k is not cls

--- a/metisp/pymetis/src/pymetis/engine/core/parametrizable.py
+++ b/metisp/pymetis/src/pymetis/engine/core/parametrizable.py
@@ -195,7 +195,15 @@ class ParametrizableContainer(Parametrizable, ABC):
             # Copy the entire type so that we do not mess up the original one
             new_class: cls.Meta._T = type(item_class.__name__, item_class.__bases__, dict(item_class.__dict__))
             new_class.specialize(**(item_class.tag_parameters() | parameters))
-            Msg.debug(cls.__qualname__, f"{item_class.__name__} => {item_class.__bases__} {new_class.name()}")
+
+            # Re-attempt registration now that the template may be fully resolved
+            if "{" not in new_class._name_template:
+                registry = next(
+                    (b.__dict__["_registry"] for b in new_class.__mro__ if "_registry" in b.__dict__),
+                    None,
+                )
+                if registry is not None and new_class._name_template not in registry:
+                    registry[new_class._name_template] = new_class
 
             if (klass := cls.Meta._T.find(new_class._name_template)) is None:
                 setattr(cls, name, new_class)

--- a/metisp/pymetis/src/pymetis/engine/dataitems/dataitem.py
+++ b/metisp/pymetis/src/pymetis/engine/dataitems/dataitem.py
@@ -132,7 +132,7 @@ class DataItem(ParametrizableItem):
         return self._hdus
 
     def __init__(self,
-                 primary_header: CplPropertyList = CplPropertyList(),
+                 primary_header: Optional[CplPropertyList],
                  *hdus: Hdu,
                  filename: Optional[Path] = None):
         if self._abstract or not self.__regex_pattern.match(self.name()):
@@ -158,7 +158,7 @@ class DataItem(ParametrizableItem):
         self._used: bool = False
 
         self.filename = filename
-        self.primary_header = primary_header
+        self.primary_header = primary_header if primary_header is not None else CplPropertyList()
         # Currently all items are expected to have an empty primary HDU
         self._hdus: dict[str, Hdu] = {}
 
@@ -260,7 +260,7 @@ class DataItem(ParametrizableItem):
 
         primary_header = cpl.core.PropertyList.load(frame.file, 0)
 
-        return klass(primary_header, filename=frame.file, *hdus)
+        return klass(primary_header, *hdus, filename=frame.file)
 
     def load_data(self,
                   extension: int | str) -> Image | Table | None:
@@ -290,6 +290,10 @@ class DataItem(ParametrizableItem):
                 return self[extension].klass.load(self.filename, cpl.core.Type.FLOAT, self._hdus[extension].extno)
             elif self[extension].klass == Table:
                 return self[extension].klass.load(self.filename, self._hdus[extension].extno)
+            elif self[extension].klass == ImageList:
+                return self[extension].klass.load(self.filename, self._hdus[extension].extno)
+            else:
+                raise KeyError
         except cpl.core.DataNotFoundError as exc:
             Msg.error(self.__class__.__qualname__,
                       f"Failed to load data from extension '{extension}' from file {self.filename}")
@@ -512,4 +516,4 @@ class DataItem(ParametrizableItem):
         for name, hdu in self._hdus.items():
             if self._hdus[name].extno == index:
                 return name
-
+        raise KeyError(f"HDU '{index}' not found in {self.filename}")

--- a/metisp/pymetis/src/pymetis/engine/dataitems/dataitem.py
+++ b/metisp/pymetis/src/pymetis/engine/dataitems/dataitem.py
@@ -32,7 +32,7 @@ from pymetis.engine.core.parameter import ParameterList
 from pymetis.engine.core.parametrizable import ParametrizableItem
 
 
-class DataItem(ParametrizableItem):
+class DataItem(ParametrizableItem, abstract=True):
     """
     The `DataItem` class encapsulates a single data item:
     the smallest standalone unit of detector data or a product of a recipe.
@@ -69,6 +69,8 @@ class DataItem(ParametrizableItem):
     # >>>     'DET3.DATA': Image,
     # >>>     'DET4.DATA': Image,
     # >>> }
+
+    _registry: ClassVar[dict[str, type[Self]]] = {}
 
     # [Hacky] A regex to match the name (mostly to make sure we are not instantiating a partially specialized class)
     __regex_pattern: re.Pattern = re.compile(r"^[A-Z]+[A-Z0-9_]+[A-Z0-9]+$")

--- a/metisp/pymetis/src/pymetis/engine/dataitems/dataitem.py
+++ b/metisp/pymetis/src/pymetis/engine/dataitems/dataitem.py
@@ -26,7 +26,6 @@ from typing import Optional, Generator, Self, final, Union, ClassVar
 import cpl
 from cpl.core import Msg, Image, Table, ImageList, PropertyList as CplPropertyList
 
-import pymetis
 from .hdu import Hdu
 from pymetis.engine.core.format import partial_format
 from pymetis.engine.core.parameter import ParameterList
@@ -263,7 +262,7 @@ class DataItem(ParametrizableItem):
         return klass(primary_header, *hdus, filename=frame.file)
 
     def load_data(self,
-                  extension: int | str) -> Image | Table | None:
+                  extension: int | str) -> Image | Table | ImageList | None:
         """
         Load the associated data (image or a table).
 
@@ -291,7 +290,7 @@ class DataItem(ParametrizableItem):
             elif self[extension].klass == Table:
                 return self[extension].klass.load(self.filename, self._hdus[extension].extno)
             elif self[extension].klass == ImageList:
-                return self[extension].klass.load(self.filename, self._hdus[extension].extno)
+                return self[extension].klass.load(self.filename, cpl.core.Type.FLOAT, self._hdus[extension].extno)
             else:
                 raise KeyError
         except cpl.core.DataNotFoundError as exc:
@@ -436,34 +435,6 @@ class DataItem(ParametrizableItem):
             'group': self.frame_group().name,
         }
 
-    @classmethod
-    def input_for_recipes(cls) -> Generator['PipelineRecipe', None, None]:
-        """
-        List all PipelineRecipe classes that use this Input.
-        Warning: heavy introspection.
-        Useful for reconstruction of DRLD input/product cards.
-        """
-        for (name, klass) in inspect.getmembers(
-            pymetis.recipes,
-            lambda x: inspect.isclass(x) and x.Impl.InputSet is not None):
-            for (n, kls) in inspect.getmembers(klass.Impl.InputSet, lambda x: inspect.isclass(x)):
-                if issubclass(kls, cls):
-                    yield klass
-
-    @classmethod
-    def product_of_recipes(cls) -> Generator['PipelineRecipe', None, None]:
-        """
-        List all PipelineRecipe classes that output this as a product.
-        Warning: heavy introspection.
-        Useful for reconstruction of DRLD input/product cards.
-        """
-        for (name, klass) in inspect.getmembers(
-                pymetis.recipes,     # FixMe This introduces undesired coupling, remove
-                lambda x: inspect.isclass(x) and x.Impl is not None
-        ):
-            for (n, kls) in inspect.getmembers(klass.Impl, lambda x: inspect.isclass(x)):
-                if issubclass(kls, cls):
-                    yield klass
 
     @classmethod
     @final

--- a/metisp/pymetis/src/pymetis/engine/inputs/input.py
+++ b/metisp/pymetis/src/pymetis/engine/inputs/input.py
@@ -157,7 +157,7 @@ class PipelineInput:
     def as_dict(self) -> dict[str, Any]:
         return {
             'item': self.Item,
-            'required': self.required,
+            'required': self.required(),
         }
 
     @classmethod

--- a/metisp/pymetis/src/pymetis/engine/inputs/input.py
+++ b/metisp/pymetis/src/pymetis/engine/inputs/input.py
@@ -176,9 +176,8 @@ class PipelineInput:
         assert cls.Item.name() is not None, f"{cls.Item.__qualname__} has no name"
         assert cls.Item.description() is not None, f"{cls.Item.__qualname__} has no description defined"
 
-        return (f"    {cls.Item.name():<36}[{cls._multiplicity}]{' (optional)' if not cls._required else '           '}"
+        return (f"  {cls.Item.name():<36}[{cls._multiplicity}]{' (optional)' if not cls._required else '           '}"
                 f" {cls.Item.description()}")
-#                f"{f'\n{' ' * 84}'.join([x.__qualname__ for x in set(cls.input_for_recipes())])}")
 
     @property
     @abstractmethod

--- a/metisp/pymetis/src/pymetis/engine/inputs/inputset.py
+++ b/metisp/pymetis/src/pymetis/engine/inputs/inputset.py
@@ -77,7 +77,7 @@ class PipelineInputSet(ABC):
 
         # Now iterate over all defined Inputs, instantiate them and feed them the frameset to filter.
         Msg.debug(self.__class__.__qualname__, "Instantiating inputs")
-        for (name, input_class) in self.list_classes():
+        for (name, input_class) in self.list_input_classes():
             inp = input_class(frameset)
             # FixMe: very hacky for now: determine the name of the instance from the name of the class
             self.__setattr__(self.__make_snake.sub('_', self.__cut_input.sub('', name)).lower(), inp)
@@ -95,7 +95,7 @@ class PipelineInputSet(ABC):
         """
         Msg.debug(cls.__qualname__, f"Now specializing {cls.__qualname__} for {parameters}")
 
-        for name, inp in cls.list_classes():
+        for name, inp in cls.list_input_classes():
             old_class = inp.Item
             # Copy the entire type so that we do not mess up the original one
             new_class = type(inp.Item.__name__, inp.Item.__bases__, dict(inp.Item.__dict__))
@@ -113,7 +113,7 @@ class PipelineInputSet(ABC):
                           f"{klass.__qualname__} ({klass.name()})")
 
     @classmethod
-    def list_classes(cls) -> list[tuple[str, type[PipelineInput]]]:
+    def list_input_classes(cls) -> list[tuple[str, type[PipelineInput]]]:
         """
         List all input classes within this input set.
 
@@ -124,7 +124,7 @@ class PipelineInputSet(ABC):
     @classmethod
     def list_descriptions(cls) -> str:
         return '\n'.join(
-            sorted([product_type.extended_description_line(name) for (name, product_type) in cls.list_classes()])
+            sorted([product_type.extended_description_line(name) for (name, product_type) in cls.list_input_classes()])
         )
 
     def validate(self) -> None:

--- a/metisp/pymetis/src/pymetis/engine/inputs/inputset.py
+++ b/metisp/pymetis/src/pymetis/engine/inputs/inputset.py
@@ -21,7 +21,6 @@ import inspect
 import pprint
 import re
 
-from abc import ABC
 from typing import Any, Callable, Optional
 
 import cpl

--- a/metisp/pymetis/src/pymetis/engine/inputs/inputset.py
+++ b/metisp/pymetis/src/pymetis/engine/inputs/inputset.py
@@ -96,21 +96,24 @@ class PipelineInputSet(ABC):
         Msg.debug(cls.__qualname__, f"Now specializing {cls.__qualname__} for {parameters}")
 
         for name, inp in cls.list_input_classes():
+            new_input = type(inp.__name__, (inp,), {})
             old_class = inp.Item
             # Copy the entire type so that we do not mess up the original one
             new_class = type(inp.Item.__name__, inp.Item.__bases__, dict(inp.Item.__dict__))
             new_class.specialize(**(new_class.tag_parameters() | parameters))
 
             if (klass := DataItem.find(new_class._name_template)) is None:
-                inp.Item = new_class
+                new_input.Item = new_class
                 Msg.debug(cls.__qualname__,
                           f" ! Cannot specialize {old_class.__qualname__} ({old_class.name()}) for {parameters}, "
                           f"{inp.Item.__qualname__} is now {new_class.__qualname__} ({new_class.name()})")
             else:
-                inp.Item = klass
+                new_input.Item = klass
                 Msg.debug(cls.__qualname__,
                           f" - {inp.__qualname__} data item {inp.Item.__qualname__} specialized to "
                           f"{klass.__qualname__} ({klass.name()})")
+
+            setattr(cls, name, new_input)
 
     @classmethod
     def list_input_classes(cls) -> list[tuple[str, type[PipelineInput]]]:

--- a/metisp/pymetis/src/pymetis/engine/inputs/inputset.py
+++ b/metisp/pymetis/src/pymetis/engine/inputs/inputset.py
@@ -18,6 +18,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
 import inspect
+import pprint
 import re
 
 from abc import ABC
@@ -26,11 +27,11 @@ from typing import Any, Callable, Optional
 import cpl
 from cpl.core import Msg
 
-from pymetis.engine.dataitems import DataItem
+from pymetis.engine.core.parametrizable import ParametrizableMeta, ParametrizableContainer
 from pymetis.engine.inputs.input import PipelineInput
 
 
-class PipelineInputSet(ABC):
+class PipelineInputSet(ParametrizableContainer):
     """
     The `PipelineInputSet` class is a utility class for a recipe dealing with the input data.
     It reads and filters the input FrameSet, categorizes the frames by their metadata,
@@ -89,33 +90,6 @@ class PipelineInputSet(ABC):
                       f" - {inp.Item.name()}")
 
     @classmethod
-    def specialize(cls, **parameters) -> None:
-        """
-        Specialize all input classes within this input set, based on tunable parameters.
-        """
-        Msg.debug(cls.__qualname__, f"Now specializing {cls.__qualname__} for {parameters}")
-
-        for name, inp in cls.list_input_classes():
-            new_input = type(inp.__name__, (inp,), {})
-            old_class = inp.Item
-            # Copy the entire type so that we do not mess up the original one
-            new_class = type(inp.Item.__name__, inp.Item.__bases__, dict(inp.Item.__dict__))
-            new_class.specialize(**(new_class.tag_parameters() | parameters))
-
-            if (klass := DataItem.find(new_class._name_template)) is None:
-                new_input.Item = new_class
-                Msg.debug(cls.__qualname__,
-                          f" ! Cannot specialize {old_class.__qualname__} ({old_class.name()}) for {parameters}, "
-                          f"{inp.Item.__qualname__} is now {new_class.__qualname__} ({new_class.name()})")
-            else:
-                new_input.Item = klass
-                Msg.debug(cls.__qualname__,
-                          f" - {inp.__qualname__} data item {inp.Item.__qualname__} specialized to "
-                          f"{klass.__qualname__} ({klass.name()})")
-
-            setattr(cls, name, new_input)
-
-    @classmethod
     def list_input_classes(cls) -> list[tuple[str, type[PipelineInput]]]:
         """
         List all input classes within this input set.
@@ -140,15 +114,18 @@ class PipelineInputSet(ABC):
                 - and assign their values as attributes of the inputset
         """
         Msg.debug(self.__class__.__qualname__,
-                  f"Validating the inputset {self.inputs}")
+                  f"Validating the inputset {pprint.pformat(self.inputs)}")
 
         if len(self.inputs) == 0:
             raise NotImplementedError("PipelineInputSet must define at least one input.")
 
-        for inp in self.inputs:
-            inp.validate()
-            Msg.debug(self.__class__.__qualname__, f"Tag parameters for {inp} are {inp.Item.tag_parameters()}")
-            self.tag_matches |= inp.Item.tag_parameters()
+        try:
+            for inp in self.inputs:
+                inp.validate()
+                Msg.debug(self.__class__.__qualname__, f"Tag parameters for {inp} are {inp.Item.tag_parameters()}")
+                self.tag_matches |= inp.Item.tag_parameters()
+        except cpl.core.DataNotFoundError as e:
+            Msg.error(self.__class__.__qualname__, e)
 
 
     def print_debug(self, *, offset: int = 0) -> None:

--- a/metisp/pymetis/src/pymetis/engine/inputs/inputset.py
+++ b/metisp/pymetis/src/pymetis/engine/inputs/inputset.py
@@ -69,7 +69,7 @@ class PipelineInputSet(ABC):
         By default, there is nothing: no inputs, no tag_parameters.
         This feels hacky but makes it much more comfortable as you do not need to define Inputs manually.
         """
-        self.inputs: set[PipelineInput] = set()         # A set of all inputs for this InputSet.
+        self.inputs: frozenset[PipelineInput] = frozenset() # All inputs for this InputSet.
         self.frameset: cpl.ui.FrameSet = frameset
 
         # Tag parameter matching this instance of InputSet. Might come from DataItem matches or hard-coded from mixins.

--- a/metisp/pymetis/src/pymetis/engine/inputs/inputset.py
+++ b/metisp/pymetis/src/pymetis/engine/inputs/inputset.py
@@ -53,6 +53,7 @@ class PipelineInputSet(ABC):
 
     def __init_subclass__(cls, abstract=False, **params):
         cls.__abstract = abstract
+        super().__init_subclass__(**params)
 
         #if cls.__abstract:
         #    pass

--- a/metisp/pymetis/src/pymetis/engine/inputs/multiple.py
+++ b/metisp/pymetis/src/pymetis/engine/inputs/multiple.py
@@ -103,8 +103,8 @@ class MultiplePipelineInput(PipelineInput):
         shapes = [image.shape for image in images]
         if len(set(shapes)) != 1:
             msg = f"Image shapes inconsistent: {shapes}"
-            Msg.error(self.__class__.__qualname__, msg)
             raise cpl.core.BadFileFormatError(msg)
+
         return ImageList(images)
 
     def set_cpl_attributes(self):

--- a/metisp/pymetis/src/pymetis/engine/inputs/single.py
+++ b/metisp/pymetis/src/pymetis/engine/inputs/single.py
@@ -48,16 +48,17 @@ class SinglePipelineInput(PipelineInput):
         """
         Msg.debug(self.__class__.__qualname__, f"Loading {frameset}")
         if (count := len(frameset)) == 0:
-            Msg.warning(self.__class__.__qualname__,
-                        f"No frames found!")
+            Msg.error(self.__class__.__qualname__,
+                      f"No frames found!")
         elif count > 1:
             Msg.warning(self.__class__.__qualname__,
-                        f"Expected a single frame, but found {count} of them!")
+                        f"Expected a single frame, but found {count} of them! Using the first one.")
+            self.frame = frameset[0]
         else:
             Msg.debug(self.__class__.__qualname__,
                       f"Found a {self.Item.__qualname__} frame {frameset[0].file}")
+            self.frame = frameset[0]
 
-        self.frame = frameset[0]
 
     def load_structure(self) -> None:
         if self.item is not None:

--- a/metisp/pymetis/src/pymetis/engine/qc/parameter.py
+++ b/metisp/pymetis/src/pymetis/engine/qc/parameter.py
@@ -52,12 +52,12 @@ class QcParameter(ParametrizableItem):
         """
         Return a formatted description line for the man page.
         """
-        name = f"{cls.name():<36s}"
+        name = f"{cls.name():<35s}"
         unit_default = f"[{str(cls._unit)}, default {str(cls._default)}]"
         description = f"{cls.description():<60}"
 
         # [5:] is there to get rid of "Type." prefix
-        return (f"{name} {f'{python_to_cpl_type(cls._type)}'[5:]:<13s} "
+        return (f"{name} {f'{python_to_cpl_type(cls._type)}'[5:]:<14s} "
                 f"{unit_default:<32s}"
                 f"{description} ")
 

--- a/metisp/pymetis/src/pymetis/engine/qc/parameter.py
+++ b/metisp/pymetis/src/pymetis/engine/qc/parameter.py
@@ -17,7 +17,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 """
 from types import NoneType
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Self
 
 import cpl
 
@@ -36,6 +36,8 @@ class QcParameter(ParametrizableItem):
     _default: ClassVar[Any] = None
     _description_template: ClassVar[str] = "<no description provided>"
     _comment: ClassVar[str] = ""
+
+    _registry: ClassVar[dict[str, type[Self]]] = {}
 
     def __init__(self, value: Any):
         assert isinstance(value, self._type), \

--- a/metisp/pymetis/src/pymetis/engine/recipes/impl.py
+++ b/metisp/pymetis/src/pymetis/engine/recipes/impl.py
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 """
-
+import pprint
 from abc import abstractmethod, ABC
 from typing import Dict, Any, final, Optional
 
@@ -100,8 +100,13 @@ class RecipeImpl(Parametrizable, ABC):
         For instance, `recipe_{band}_{target}` can specify band=LM, but no target,
         resulting in a partial specialiation. The target has to be supplied from the actual data.)
         """
-        cls.ProductSet.promote(**parameters)
-        cls.Qc.promote(**parameters)
+        try:
+            cls.ProductSet.promote(**parameters)
+            cls.Qc.promote(**parameters)
+        except TypeError as e:
+            pprint.pprint(e)
+            Msg.error(cls.__qualname__, e)
+            raise e
 
     def run(self) -> cpl.ui.FrameSet:
         """

--- a/metisp/pymetis/src/pymetis/engine/recipes/recipe.py
+++ b/metisp/pymetis/src/pymetis/engine/recipes/recipe.py
@@ -51,7 +51,7 @@ class Recipe(cpl.ui.PyRecipe):
                          "If you see this in a recipe, override its `_description` attribute.")
 
     # More internal attributes follow. These are **not** required by pyesorex and are specific to A*.
-    _matched_keywords: set[str] = set()
+    _matched_keywords: set[str] = None
     # Verbal description of the algorithm
     _algorithm: str = "<no algorithm provided>"
 
@@ -75,14 +75,17 @@ class Recipe(cpl.ui.PyRecipe):
         self.implementation = self.Impl(self, frameset, settings)
         return self.implementation.run()
 
-    def _list_inputs(self) -> list[tuple[str, type[PipelineInput]]]:
-        return self.Impl.InputSet.list_classes()
+    @classmethod
+    def _list_inputs(cls) -> list[tuple[str, type[PipelineInput]]]:
+        return cls.Impl.InputSet.list_classes()
 
-    def _list_products(self) -> list[tuple[str, type[DataItem]]]:
-        return self.Impl.ProductSet.list_classes()
+    @classmethod
+    def _list_products(cls) -> list[tuple[str, type[DataItem]]]:
+        return cls.Impl.ProductSet.list_classes()
 
-    def _list_qc_parameters(self) -> list[tuple[str, type[QcParameter]]]:
-        return self.Impl.Qc.list_classes()
+    @classmethod
+    def _list_qc_parameters(cls) -> list[tuple[str, type[QcParameter]]]:
+        return cls.Impl.Qc.list_classes()
 
     @staticmethod
     def _format_spacing(text: str, title: str, offset: int = 4) -> str:
@@ -96,28 +99,29 @@ class Recipe(cpl.ui.PyRecipe):
         return fix_spacing.sub('\n' + ' ' * offset, fix_first_space.sub(' ' * offset, text)) \
             if text is not None else f'<no {title} defined>'
 
-    def _build_description(self) -> str:
+    @classmethod
+    def _build_description(cls) -> str:
         """
         Automatically build the `description` attribute from available attributes.
         Everything inside this should only depend on the class, never on an instance.
         """
-        if self._matched_keywords is None:
+        if cls._matched_keywords is None:
             matched_keywords = '<not defined>'
-        elif len(self._matched_keywords) == 0:
+        elif len(cls._matched_keywords) == 0:
             matched_keywords = '--- none ---'
         else:
-            matched_keywords = '\n    '.join(self._matched_keywords)
+            matched_keywords = '\n    '.join(cls._matched_keywords)
 
-        self.Impl.specialize()
+        cls.Impl.specialize()
 
         inputs = '\n'.join(sorted([input_type.extended_description_line(name)
-                                   for (name, input_type) in self._list_inputs()]))
-        products = self._format_spacing(self.Impl.ProductSet.list_descriptions(), 6)
-        qc_parameters = self._format_spacing(self.Impl.Qc.list_descriptions(), 6)
-        algorithm = self._format_spacing(self._algorithm, 'algorithm', 4)
-        description = self._format_spacing(self._description, 'description', 2)
+                                   for (name, input_type) in cls._list_inputs()]))
+        products = cls._format_spacing(cls.Impl.ProductSet.list_descriptions(), 'products', 6)
+        qc_parameters = cls._format_spacing(cls.Impl.Qc.list_descriptions(), 'QC parameters', 6)
+        algorithm = cls._format_spacing(cls._algorithm, 'algorithm', 4)
+        description = cls._format_spacing(cls._description, 'description', 2)
 
-        return f"""{self.synopsis}\n\n{description}\n
+        return f"""{cls.synopsis}\n\n{description}\n
   Matched keywords
     {matched_keywords}
   Inputs\n{inputs}

--- a/metisp/pymetis/src/pymetis/engine/recipes/recipe.py
+++ b/metisp/pymetis/src/pymetis/engine/recipes/recipe.py
@@ -18,11 +18,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 """
 import inspect
 import re
-from typing import Any, Generator
+from typing import Any, Generator, Self, ClassVar
 
 import cpl
 
-import pymetis
 from ..core.parameter import ParameterList
 from ..dataitems import DataItem
 from ..qc import QcParameter
@@ -61,11 +60,17 @@ class Recipe(cpl.ui.PyRecipe):
     # Default implementation class. This will not work, because it is abstract, but this is an abstract class too.
     Impl: type[RecipeImpl] = RecipeImpl
 
+    _registry: ClassVar[dict[str, type[Self]]] = {}
+
     def __init__(self):
         super().__init__()
         # Build a fancy description from attributes
         self._description: str = self._build_description()
         self.implementation: RecipeImpl | None = None
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls._registry[cls._name] = cls
 
     def run(self, frameset: cpl.ui.FrameSet, settings: dict[str, Any]) -> cpl.ui.FrameSet:
         """
@@ -77,54 +82,34 @@ class Recipe(cpl.ui.PyRecipe):
         return self.implementation.run()
 
     @classmethod
-    def _list_dataitem_inputs(cls, dataitem_class: type[DataItem]) -> Generator['PipelineRecipe', None, None]:
+    def _list_dataitems_input(cls, dataitem_class: type[DataItem]) -> Generator[Self, None, None]:
         """
-        List all PipelineRecipe classes that use a particular DataItem as an input.
+        List all Recipe classes that use a particular DataItem as an input.
         Warning: heavy introspection.
         Useful for reconstruction of DRLD input/product cards.
         """
-        for (name, klass) in inspect.getmembers(
-                pymetis.recipes,  # FixMe This introduces undesired coupling, remove
-                lambda x: inspect.isclass(x) and x.Impl.InputSet is not None):
-            for (n, kls) in inspect.getmembers(klass.Impl.InputSet, lambda x: inspect.isclass(x)):
+        for (name, klass) in cls._registry.items():
+            for (n, kls) in inspect.getmembers(klass.Impl.InputSet,
+                                               lambda x: (inspect.isclass(x) and issubclass(x, PipelineInput))):
+                if issubclass(kls.Item, dataitem_class):
+                    yield klass
+
+    @classmethod
+    def _list_dataitems_product(cls, dataitem_class: type[DataItem]) -> Generator[Self, None, None]:
+        """
+        List all Recipe classes that have a particular DataItem as a product.
+        Warning: heavy introspection.
+        Useful for reconstruction of DRLD input/product cards.
+        """
+        for (name, klass) in cls._registry.items():
+            for (n, kls) in inspect.getmembers(klass.Impl.ProductSet,
+                                               lambda x: inspect.isclass(x)):
                 if issubclass(kls, dataitem_class):
                     yield klass
 
-# --------------------------------------------------------------------------------------------------------
-    @classmethod
-    def input_for_recipes(cls) -> Generator['PipelineRecipe', None, None]:
-        """
-        List all PipelineRecipe classes that use this Input.
-        Warning: heavy introspection.
-        Useful for reconstruction of DRLD input/product cards.
-        """
-        for (name, klass) in inspect.getmembers(
-                pymetis.recipes,  # FixMe This introduces undesired coupling, remove
-                lambda x: inspect.isclass(x) and x.Impl.InputSet is not None):
-            for (n, kls) in inspect.getmembers(klass.Impl.InputSet, lambda x: inspect.isclass(x)):
-                if issubclass(kls, cls):
-                    yield klass
-
-    @classmethod
-    def product_of_recipes(cls) -> Generator['PipelineRecipe', None, None]:
-        """
-        List all PipelineRecipe classes that output this as a product.
-        Warning: heavy introspection.
-        Useful for reconstruction of DRLD input/product cards.
-        """
-        for (name, klass) in inspect.getmembers(
-                pymetis.recipes,     # FixMe This introduces undesired coupling, remove
-                lambda x: inspect.isclass(x) and x.Impl is not None
-        ):
-            for (n, kls) in inspect.getmembers(klass.Impl, lambda x: inspect.isclass(x)):
-                if issubclass(kls, cls):
-                    yield klass
-
-# --------------------------------------------------------------------------------------------------------
-
     @classmethod
     def _list_inputs(cls) -> list[tuple[str, type[PipelineInput]]]:
-        return cls.Impl.InputSet.list_classes()
+        return cls.Impl.InputSet.list_input_classes()
 
     @classmethod
     def _list_products(cls) -> list[tuple[str, type[DataItem]]]:
@@ -157,24 +142,24 @@ class Recipe(cpl.ui.PyRecipe):
         elif len(cls._matched_keywords) == 0:
             matched_keywords = '--- none ---'
         else:
-            matched_keywords = '\n    '.join(cls._matched_keywords)
+            matched_keywords = '\n  '.join(cls._matched_keywords)
 
         cls.Impl.specialize()
 
         inputs = '\n'.join(sorted([input_type.extended_description_line(name)
                                    for (name, input_type) in cls._list_inputs()]))
-        products = cls._format_spacing(cls.Impl.ProductSet.list_descriptions(), 'products', 6)
-        qc_parameters = cls._format_spacing(cls.Impl.Qc.list_descriptions(), 'QC parameters', 6)
-        algorithm = cls._format_spacing(cls._algorithm, 'algorithm', 4)
-        description = cls._format_spacing(cls._description, 'description', 2)
+        products = cls._format_spacing(cls.Impl.ProductSet.list_descriptions(), 'products', 2)
+        qc_parameters = cls._format_spacing(cls.Impl.Qc.list_descriptions(), 'QC parameters', 2)
+        algorithm = cls._format_spacing(cls._algorithm, 'algorithm', 2)
+        description = cls._format_spacing(cls._description, 'description', 0)
 
-        return f"""{cls.synopsis}\n\n{description}\n
-  Matched keywords
-    {matched_keywords}
-  Inputs\n{inputs}
-  Outputs\n{products}
-  QC parameters\n{qc_parameters}
-  Algorithm\n{algorithm}
+        return f"""{cls._synopsis}\n\n{description}\n
+Matched keywords
+  {matched_keywords}
+Inputs\n{inputs}
+Outputs\n{products}
+QC parameters\n{qc_parameters}
+Algorithm\n{algorithm}
 """
 
     @property

--- a/metisp/pymetis/src/pymetis/engine/recipes/recipe.py
+++ b/metisp/pymetis/src/pymetis/engine/recipes/recipe.py
@@ -21,6 +21,7 @@ import re
 from typing import Any, Generator, Self, ClassVar
 
 import cpl
+from astropy.utils import classproperty
 
 from ..core.parameter import ParameterList
 from ..dataitems import DataItem
@@ -65,12 +66,16 @@ class Recipe(cpl.ui.PyRecipe):
     def __init__(self):
         super().__init__()
         # Build a fancy description from attributes
-        self._description: str = self._build_description()
         self.implementation: RecipeImpl | None = None
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
+        cls._description: str = cls._build_description()
         cls._registry[cls._name] = cls
+
+    @classproperty
+    def description(cls) -> str:
+        return cls._description
 
     def run(self, frameset: cpl.ui.FrameSet, settings: dict[str, Any]) -> cpl.ui.FrameSet:
         """

--- a/metisp/pymetis/src/pymetis/engine/recipes/recipe.py
+++ b/metisp/pymetis/src/pymetis/engine/recipes/recipe.py
@@ -51,7 +51,7 @@ class Recipe(cpl.ui.PyRecipe):
                          "If you see this in a recipe, override its `_description` attribute.")
 
     # More internal attributes follow. These are **not** required by pyesorex and are specific to A*.
-    _matched_keywords: set[str] = None
+    _matched_keywords: frozenset[str] = None
     # Verbal description of the algorithm
     _algorithm: str = "<no algorithm provided>"
 

--- a/metisp/pymetis/src/pymetis/engine/recipes/recipe.py
+++ b/metisp/pymetis/src/pymetis/engine/recipes/recipe.py
@@ -16,12 +16,13 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 """
-
+import inspect
 import re
-from typing import Any
+from typing import Any, Generator
 
 import cpl
 
+import pymetis
 from ..core.parameter import ParameterList
 from ..dataitems import DataItem
 from ..qc import QcParameter
@@ -74,6 +75,52 @@ class Recipe(cpl.ui.PyRecipe):
         """
         self.implementation = self.Impl(self, frameset, settings)
         return self.implementation.run()
+
+    @classmethod
+    def _list_dataitem_inputs(cls, dataitem_class: type[DataItem]) -> Generator['PipelineRecipe', None, None]:
+        """
+        List all PipelineRecipe classes that use a particular DataItem as an input.
+        Warning: heavy introspection.
+        Useful for reconstruction of DRLD input/product cards.
+        """
+        for (name, klass) in inspect.getmembers(
+                pymetis.recipes,  # FixMe This introduces undesired coupling, remove
+                lambda x: inspect.isclass(x) and x.Impl.InputSet is not None):
+            for (n, kls) in inspect.getmembers(klass.Impl.InputSet, lambda x: inspect.isclass(x)):
+                if issubclass(kls, dataitem_class):
+                    yield klass
+
+# --------------------------------------------------------------------------------------------------------
+    @classmethod
+    def input_for_recipes(cls) -> Generator['PipelineRecipe', None, None]:
+        """
+        List all PipelineRecipe classes that use this Input.
+        Warning: heavy introspection.
+        Useful for reconstruction of DRLD input/product cards.
+        """
+        for (name, klass) in inspect.getmembers(
+                pymetis.recipes,  # FixMe This introduces undesired coupling, remove
+                lambda x: inspect.isclass(x) and x.Impl.InputSet is not None):
+            for (n, kls) in inspect.getmembers(klass.Impl.InputSet, lambda x: inspect.isclass(x)):
+                if issubclass(kls, cls):
+                    yield klass
+
+    @classmethod
+    def product_of_recipes(cls) -> Generator['PipelineRecipe', None, None]:
+        """
+        List all PipelineRecipe classes that output this as a product.
+        Warning: heavy introspection.
+        Useful for reconstruction of DRLD input/product cards.
+        """
+        for (name, klass) in inspect.getmembers(
+                pymetis.recipes,     # FixMe This introduces undesired coupling, remove
+                lambda x: inspect.isclass(x) and x.Impl is not None
+        ):
+            for (n, kls) in inspect.getmembers(klass.Impl, lambda x: inspect.isclass(x)):
+                if issubclass(kls, cls):
+                    yield klass
+
+# --------------------------------------------------------------------------------------------------------
 
     @classmethod
     def _list_inputs(cls) -> list[tuple[str, type[PipelineInput]]]:

--- a/metisp/pymetis/src/pymetis/engine/recipes/recipe.py
+++ b/metisp/pymetis/src/pymetis/engine/recipes/recipe.py
@@ -156,7 +156,7 @@ class Recipe(cpl.ui.PyRecipe):
         products = cls._format_spacing(cls.Impl.ProductSet.list_descriptions(), 'products', 2)
         qc_parameters = cls._format_spacing(cls.Impl.Qc.list_descriptions(), 'QC parameters', 2)
         algorithm = cls._format_spacing(cls._algorithm, 'algorithm', 2)
-        description = cls._format_spacing(cls._description, 'description', 0)
+        description = cls._format_spacing(cls.description, 'description', 0)
 
         return f"""{cls._synopsis}\n\n{description}\n
 Matched keywords

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/__init__.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/__init__.py
@@ -16,3 +16,20 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 """
+
+from .adc import *
+from .background import *
+from .chophome import *
+from .distortion import *
+from .hci import *
+from .img import *
+from .linearity import *
+from .lss import *
+from .masterdark import *
+from .masterflat import *
+from .molecfit import *
+from .pupil import *
+from .raw import *
+from .rsrf import *
+
+from .badpixmap import *

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/adc/adc.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/adc/adc.py
@@ -31,7 +31,7 @@ class AdcSlitloss(TableDataItem, abstract=True):
     _description_template = "Table with ADC induced {band} slitlosses"
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB  # TBC
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'DRS.SLIT'}
+    _oca_keywords = frozenset({'PRO.CATG', 'DRS.SLIT'})
 
 
 class LmAdcSlitloss(BandLmMixin, AdcSlitloss):
@@ -47,6 +47,7 @@ class AdcSlitlossRaw(Raw, abstract=True):
     _title_template = r'{band} ADC slit loss raw'
     _description_template = "Raw files for ADC slitloss determination (TBD)."
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
+    _oca_keywords = frozenset({'PRO.CATG'})
 
     _schema = {
         'PRIMARY': None,

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/background/background.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/background/background.py
@@ -30,7 +30,7 @@ class Background(ImageDataItem, abstract=True):
     _description_template = r"Thermal background subtracted images of {target} {band} exposures."
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'})
 
     _schema = {
         'PRIMARY': None,

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/background/subtracted.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/background/subtracted.py
@@ -30,7 +30,7 @@ class BackgroundSubtracted(ImageDataItem, abstract=True):
     _description_template = r"Thermal background subtracted images of science {band} {target} exposures."
     _frame_group = cpl.ui.Frame.FrameGroup.RAW
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'} # maybe
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'}) # maybe
 
     _schema = {
         'PRIMARY': None,

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/badpixmap.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/badpixmap.py
@@ -30,7 +30,7 @@ class BadPixMap(ImageDataItem, abstract=True):
     _description_template = "Bad pixel map. Warning: may contain detector masks."
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
-    _oca_keywords = {'PRO.CATG'}
+    _oca_keywords = frozenset({'PRO.CATG'})
 
     _schema = {
         'PRIMARY': None,

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/chophome/chophome.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/chophome/chophome.py
@@ -32,7 +32,7 @@ class LmChophomeCombined(BandLmMixin, ImageDataItem):
     _frame_type = cpl.ui.Frame.FrameType.IMAGE
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
     _frame_group = cpl.ui.Frame.FrameGroup.PRODUCT
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI20.NAME'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI20.NAME'})
 
     _schema = {
         'PRIMARY': None,
@@ -50,7 +50,7 @@ class LmChophomeBackground(BandLmMixin, ImageDataItem):
     _frame_type = cpl.ui.Frame.FrameType.IMAGE
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
     _frame_group = cpl.ui.Frame.FrameGroup.PRODUCT
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI19.NAME', 'INS.OPTI20.NAME'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI19.NAME', 'INS.OPTI20.NAME'})
 
     _schema = {
         'PRIMARY': None,

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/chophome/raw.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/chophome/raw.py
@@ -29,8 +29,8 @@ class LmChophomeRaw(Raw):
     _description_template = "Raw exposure of the LM image mode"
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
     _frame_group = cpl.ui.Frame.FrameGroup.RAW
-    _oca_keywords = {'DPR.CATG', 'DPR.TECH', 'DPR.TYPE',
-                     'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'}
+    _oca_keywords = frozenset({'DPR.CATG', 'DPR.TECH', 'DPR.TYPE',
+                               'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'})
 
     _schema = {
         'PRIMARY': None,

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/coadd.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/coadd.py
@@ -29,7 +29,7 @@ class SciCoadd(ImageDataItem, abstract=True):
     _title_template = r"{band} science co-added"
     _frame_group = cpl.ui.Frame.FrameGroup.PRODUCT
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'DRS.FILTER'}
+    _oca_keywords = frozenset({'PRO.CATG', 'DRS.FILTER'})
     _description_template = "{band} science co-added"
 
     _schema = {

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/combined.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/combined.py
@@ -33,7 +33,7 @@ class Combined(ImageDataItem, abstract=True):
     _description_template = r"Stacked {band} band exposures."
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
     _frame_group = cpl.ui.Frame.FrameGroup.PRODUCT
-    _oca_keywords = {'PRO.CATG', 'DRS.FILTER'}
+    _oca_keywords = frozenset({'PRO.CATG', 'DRS.FILTER'})
 
     _schema = {
         'PRIMARY': None,

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/common.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/common.py
@@ -29,7 +29,7 @@ class PersistenceMap(ImageDataItem):
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
     _description_template = "Persistence map"
-    _oca_keywords = {'PRO.CATG'}
+    _oca_keywords = frozenset({'PRO.CATG'})
     _pro_catg = r'PERSISTENCE_MAP'
 
     _schema = {
@@ -44,7 +44,7 @@ class FluxCalTable(TableDataItem):
     _description_template = "Conversion between instrumental and physical flux units"
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG'}
+    _oca_keywords = frozenset({'PRO.CATG'})
 
     _schema = {
         'PRIMARY': None,
@@ -58,7 +58,7 @@ class PinholeTable(TableDataItem):
     _description_template = "Table of pinhole locations"
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
-    _oca_keywords = {'PRO.CATG'}
+    _oca_keywords = frozenset({'PRO.CATG'})
     _pro_catg = r'PINHOLE_TABLE'
 
     _schema = {
@@ -74,6 +74,7 @@ class AtmProfile(TableDataItem):
                              "pressure and molecular abundances")
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
+    _oca_keywords = frozenset({'PRO.CATG'})
 
     _schema = {
         'PRIMARY': None,
@@ -95,7 +96,7 @@ class FluxStdCatalog(TableDataItem):
     _description_template = "Catalog of standard stars"
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
-    _oca_keywords = set()
+    _oca_keywords = frozenset()
 
 
 class AtmLineCatalog(TableDataItem):
@@ -104,7 +105,7 @@ class AtmLineCatalog(TableDataItem):
     _description_template = "Catalogue containing a line list of atmospheric molecular lines"
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG'}
+    _oca_keywords = frozenset({'PRO.CATG'})
 
 
 class LaserTable(TableDataItem):

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/distortion/raw.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/distortion/raw.py
@@ -29,8 +29,8 @@ class DistortionRaw(Raw, abstract=True):
     _title_template = "distortion raw"
     _description_template = "Raw data for distortion determination in other recipes in the {band} band."
     _frame_level = cpl.ui.Frame.FrameLevel.TEMPORARY
-    _oca_keywords = {'DPR.CATG', 'DPR.TECH', 'DPR.TYPE',
-                     'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.IFU'}
+    _oca_keywords = frozenset({'DPR.CATG', 'DPR.TECH', 'DPR.TYPE',
+                               'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.IFU'})
 
     _schema = {
         'PRIMARY': None,

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/distortion/reduced.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/distortion/reduced.py
@@ -40,15 +40,15 @@ class DistortionReduced(TableDataItem, abstract=True):
 
 
 class LmDistortionReduced(BandLmMixin, DistortionReduced):
-    _oca_keywords = DistortionReduced._oca_keywords | {'DRS.FILTER'}
+    _oca_keywords = DistortionReduced._oca_keywords | frozenset({'DRS.FILTER'})
 
 
 class NDistortionReduced(BandNMixin, DistortionReduced):
-    _oca_keywords = DistortionReduced._oca_keywords | {'DRS.FILTER'}
+    _oca_keywords = DistortionReduced._oca_keywords | frozenset({'DRS.FILTER'})
 
 
 class IfuDistortionReduced(BandIfuMixin, DistortionReduced):
-    _oca_keywords = DistortionReduced._oca_keywords | {'DRS.IFU'}
+    _oca_keywords = DistortionReduced._oca_keywords | frozenset({'DRS.IFU'})
 
     _schema = {
         'PRIMARY': None,

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/distortion/reduced.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/distortion/reduced.py
@@ -31,7 +31,7 @@ class DistortionReduced(TableDataItem, abstract=True):
     _description_template = r"Table of polynomial coefficients for distortion correction"
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
-    _oca_keywords = {'PRO.CATG'}
+    _oca_keywords = frozenset({'PRO.CATG'})
 
     _schema = {
         'PRIMARY': None,

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/distortion/table.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/distortion/table.py
@@ -33,7 +33,7 @@ class DistortionTable(TableDataItem, abstract=True):
     _description_template = r"Table of distortion coefficients for a {band} band data set"
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'DRS.IFU'}
+    _oca_keywords = frozenset({'PRO.CATG', 'DRS.IFU'})
 
     _schema = {
         'PRIMARY': None,

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/gainmap.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/gainmap.py
@@ -30,7 +30,7 @@ class GainMap(ImageDataItem, abstract=True):
     _description_template = "Gain map for the {detector} detector"
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
-    _oca_keywords = {'PRO.CATG'}
+    _oca_keywords = frozenset({'PRO.CATG'})
 
     _schema = {
         'PRIMARY': None,

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/hci/hci.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/hci/hci.py
@@ -30,7 +30,7 @@ class OffAxisPsfRaw(ImageDataItem, abstract=True):
     _description_template = "calibration ADI image data" 
     _frame_group = cpl.ui.Frame.FrameGroup.RAW
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'})
 
     _schema = {
         'PRIMARY': None,
@@ -43,7 +43,7 @@ class AdiCalibrated(ImageDataItem, abstract=True):
     _description_template = "calibration ADI image data" 
     _frame_group = cpl.ui.Frame.FrameGroup.PRODUCT
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'})
 
     _schema = {
         'PRIMARY': None,
@@ -56,7 +56,7 @@ class OnAxisPsfTemplate(ImageDataItem, abstract=True):
     _description_template = "calibration ADI image data" 
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'})
 
     _schema = {
         'PRIMARY': None,
@@ -72,7 +72,7 @@ class SciCentred(ImageDataItem, abstract=True):
     _description_template = ""
     _frame_group = cpl.ui.Frame.FrameGroup.PRODUCT
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'})
 
     _schema = {
         'PRIMARY': None,
@@ -86,7 +86,7 @@ class CentroidTab(ImageDataItem, abstract=True):
     _description_template = "" 
     _frame_group = cpl.ui.Frame.FrameGroup.PRODUCT
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'})
 
     _schema = {
         'PRIMARY': None,
@@ -100,7 +100,7 @@ class SciSpeckle(ImageDataItem, abstract=True):
     _description_template = "" 
     _frame_group = cpl.ui.Frame.FrameGroup.PRODUCT
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'})
 
     _schema = {
         'PRIMARY': None,
@@ -114,7 +114,7 @@ class SciHifilt(ImageDataItem, abstract=True):
     _description_template = "" 
     _frame_group = cpl.ui.Frame.FrameGroup.PRODUCT
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'})
 
     _schema = {
         'PRIMARY': None,
@@ -128,7 +128,7 @@ class SciDerotatedPsfsub(ImageDataItem, abstract=True):
     _description_template = "" 
     _frame_group = cpl.ui.Frame.FrameGroup.PRODUCT
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'})
 
     _schema = {
         'PRIMARY': None,
@@ -142,7 +142,7 @@ class SciDerotated(ImageDataItem, abstract=True):
     _description_template = "" 
     _frame_group = cpl.ui.Frame.FrameGroup.PRODUCT
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'})
 
     _schema = {
         'PRIMARY': None,
@@ -156,7 +156,7 @@ class SciContrastRadprof(ImageDataItem, abstract=True):
     _description_template = "" 
     _frame_group = cpl.ui.Frame.FrameGroup.PRODUCT
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'})
 
     _schema = {
         'PRIMARY': None,
@@ -170,7 +170,7 @@ class SciContrastAdi(ImageDataItem, abstract=True):
     _description_template = "" 
     _frame_group = cpl.ui.Frame.FrameGroup.PRODUCT
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'})
 
     _schema = {
         'PRIMARY': None,
@@ -184,7 +184,7 @@ class SciThroughput(ImageDataItem, abstract=True):
     _description_template = "" 
     _frame_group = cpl.ui.Frame.FrameGroup.PRODUCT
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'})
 
     _schema = {
         'PRIMARY': None,
@@ -198,7 +198,7 @@ class SciCoverage(ImageDataItem, abstract=True):
     _description_template = "" 
     _frame_group = cpl.ui.Frame.FrameGroup.PRODUCT
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'})
 
     _schema = {
         'PRIMARY': None,
@@ -212,7 +212,7 @@ class SciSnr(ImageDataItem, abstract=True):
     _description_template = "" 
     _frame_group = cpl.ui.Frame.FrameGroup.PRODUCT
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'})
 
     _schema = {
         'PRIMARY': None,
@@ -226,7 +226,7 @@ class PsfMedian(ImageDataItem, abstract=True):
     _description_template = "" 
     _frame_group = cpl.ui.Frame.FrameGroup.PRODUCT
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'})
 
     _schema = {
         'PRIMARY': None,

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/ifu/ifu.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/ifu/ifu.py
@@ -26,7 +26,7 @@ from pymetis.instruments.metis.mixins.band import BandIfuMixin
 
 
 class IfuBase(BandIfuMixin, ImageDataItem, abstract=True):
-    _oca_keywords = {'PRO.CATG', 'DRS.IFU'}
+    _oca_keywords = frozenset({'PRO.CATG', 'DRS.IFU'})
 
     _schema = {
         'PRIMARY': None,
@@ -112,7 +112,7 @@ class IfuScienceCubeCalibrated(BandIfuMixin, ImageDataItem):
     _description_template = "A telluric absorption corrected rectified spectral cube with a linear wavelength grid."
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'DRS.IFU'}
+    _oca_keywords = frozenset({'PRO.CATG', 'DRS.IFU'})
 
     _schema = {
         'PRIMARY': None,
@@ -126,4 +126,4 @@ class IfuTelluric(TableDataItem):
     _description_template = "Transmission function for the telluric correction."
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
-    _oca_keywords = {'PRO.CATG', 'DRS.IFU'}
+    _oca_keywords = frozenset({'PRO.CATG', 'DRS.IFU'})

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/ifu/raw.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/ifu/raw.py
@@ -29,9 +29,9 @@ class IfuRaw(BandIfuMixin, Raw, abstract=True):
     _description_template = r"{band} {target} raw image"
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
     _frame_group = cpl.ui.Frame.FrameGroup.RAW
-    _oca_keywords = {"DPR.CATG", "DPR.TECH", "DPR.TYPE", "INS.OPTI3.NAME",
-                     "INS.OPTI9.NAME", "INS.OPTI10.NAME", "INS.OPTI11.NAME",
-                     "DRS.IFU"}
+    _oca_keywords = frozenset({"DPR.CATG", "DPR.TECH", "DPR.TYPE", "INS.OPTI3.NAME",
+                               "INS.OPTI9.NAME", "INS.OPTI10.NAME", "INS.OPTI11.NAME",
+                               "DRS.IFU"})
     _schema = {
         'PRIMARY': None,
     } | {
@@ -52,7 +52,7 @@ class IfuSkyRaw(BandIfuMixin, Raw):
     _title_template = r"IFU sky raw"
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
     _frame_group = cpl.ui.Frame.FrameGroup.RAW
-    _oca_keywords = {"DPR.CATG", "DPR.TECH", "DPR.TYPE", "INS.OPTI3.NAME",
-                     "INS.OPTI9.NAME", "INS.OPTI10.NAME", "INS.OPTI11.NAME",
-                     "DRS.IFU"}
+    _oca_keywords = frozenset({"DPR.CATG", "DPR.TECH", "DPR.TYPE", "INS.OPTI3.NAME",
+                               "INS.OPTI9.NAME", "INS.OPTI10.NAME", "INS.OPTI11.NAME",
+                               "DRS.IFU"})
     _description_template = "Blank sky image."

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/img/basicreduced.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/img/basicreduced.py
@@ -30,7 +30,7 @@ class BasicReduced(ImageDataItem, abstract=True):
     _description_template = "Detrended {target} exposure of the {band} image mode."
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'})
 
     _schema = {
         'PRIMARY': None,
@@ -56,7 +56,7 @@ class LmSkyBasicReduced(ImageDataItem):
     _description_template = "Detrended exposure of the sky."
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'DRS.FILTER'})
 
     _schema = {
         'PRIMARY': None,
@@ -71,7 +71,7 @@ class Calibrated(ImageDataItem, abstract=True):
     _frame_type = cpl.ui.Frame.FrameType.IMAGE
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
     _frame_group = cpl.ui.Frame.FrameGroup.RAW  # This actually has to be raw as it is "primary input" (rite-of-passage)
-    _oca_keywords = {'PRO.CATG', 'DRS.FILTER'}
+    _oca_keywords = frozenset({'PRO.CATG', 'DRS.FILTER'})
 
     _schema = {
         'PRIMARY': None,
@@ -102,7 +102,7 @@ class NSciRestored(BandNMixin, ImageDataItem):
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_type = cpl.ui.Frame.FrameType.IMAGE
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
-    _oca_keywords = {'PRO.CATG', 'DRS.FILTER'}
+    _oca_keywords = frozenset({'PRO.CATG', 'DRS.FILTER'})
 
     _schema = {
         'PRIMARY': None,

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/img/raw.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/img/raw.py
@@ -31,8 +31,8 @@ class ImageRaw(Raw, abstract=True):
     _title_template = "{band} image {target} raw"
     _description_template = "Raw exposure of a {target} in the {band} image mode."
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
-    _oca_keywords = {"DPR.CATG", "DPR.TECH", "DPR.TYPE", "INS.OPTI3.NAME",
-                     "INS.OPTI9.NAME", "INS.OPTI10.NAME", "DRS.FILTER"}
+    _oca_keywords = frozenset({"DPR.CATG", "DPR.TECH", "DPR.TYPE", "INS.OPTI3.NAME",
+                               "INS.OPTI9.NAME", "INS.OPTI10.NAME", "DRS.FILTER"})
 
 
 class LmImageRaw(BandLmMixin, ImageRaw):

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/linearity/linearity.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/linearity/linearity.py
@@ -30,7 +30,7 @@ class LinearityMap(ImageDataItem, abstract=True):
     _description_template = "Coefficients for the pixel {detector} non-linearity correction"
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
-    _oca_keywords = {'PRO.CATG'}
+    _oca_keywords = frozenset({'PRO.CATG'})
 
     _schema = {
         'PRIMARY': None,

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/linearity/raw.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/linearity/raw.py
@@ -29,7 +29,7 @@ class LinearityRaw(Raw, abstract=True):
     _description_template = r"Raw data for non-linearity determination for {detector} observations"
     _frame_group = cpl.ui.Frame.FrameGroup.RAW
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'DPR.CATG', 'DPR.TECH', 'DPR.TYPE'}
+    _oca_keywords = frozenset({'DPR.CATG', 'DPR.TECH', 'DPR.TYPE'})
 
 
 class LinearityRaw2rg(Detector2rgMixin, LinearityRaw):

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/linearity/raw.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/linearity/raw.py
@@ -33,12 +33,12 @@ class LinearityRaw(Raw, abstract=True):
 
 
 class LinearityRaw2rg(Detector2rgMixin, LinearityRaw):
-    _oca_keywords = LinearityRaw._oca_keywords | {'DRS.FILTER'}
+    _oca_keywords = LinearityRaw._oca_keywords | frozenset({'DRS.FILTER'})
 
 
 class LinearityRawGeo(DetectorGeoMixin, LinearityRaw):
-    _oca_keywords = LinearityRaw._oca_keywords | {'DRS.FILTER'}
+    _oca_keywords = LinearityRaw._oca_keywords | frozenset({'DRS.FILTER'})
 
 
 class LinearityRawIfu(DetectorIfuMixin, LinearityRaw):
-    _oca_keywords = LinearityRaw._oca_keywords | {'DRS.IFU'}
+    _oca_keywords = LinearityRaw._oca_keywords | frozenset({'DRS.IFU'})

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/lss/curve.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/lss/curve.py
@@ -32,7 +32,7 @@ class LssCurve(TableDataItem, abstract=True):
     _description_template = "Trace curvature information"
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB  # TBC
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
-    _oca_keywords = {'PRO.CATG', 'DRS.SLIT'}
+    _oca_keywords = frozenset({'PRO.CATG', 'DRS.SLIT'})
 
 
 class LmLssCurve(BandLmMixin, LssCurve):
@@ -52,7 +52,7 @@ class LssDistSol(TableDataItem, abstract=True):
     _description_template = "Distortion solution for rectifying"
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB  # TBC
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'DRS.SLIT'}
+    _oca_keywords = frozenset({'PRO.CATG', 'DRS.SLIT'})
 
 
 class LmLssDistSol(BandLmMixin, LssDistSol):
@@ -72,7 +72,7 @@ class LssWaveGuess(TableDataItem, abstract=True):
     _description_template = "First guess of the wavelength solution"
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB # TBC
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'DRS.SLIT'}
+    _oca_keywords = frozenset({'PRO.CATG', 'DRS.SLIT'})
 
 
 class LmLssWaveGuess(BandLmMixin, LssWaveGuess):

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/lss/raw.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/lss/raw.py
@@ -28,9 +28,9 @@ class LssRaw(Raw, abstract=True):
     _title_template = "{band} LSS {target} raw"
     _description_template = "{band}-band long-slit spectroscopy raw exposure of a {target}"
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'DPR.CATG', 'DPR.TECH', 'DPR.TYPE',
-                     'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME',
-                     'DRS.SLIT'}
+    _oca_keywords = frozenset({'DPR.CATG', 'DPR.TECH', 'DPR.TYPE',
+                               'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME',
+                               'DRS.SLIT'})
 
 
 class LmLssRaw(BandLmMixin, LssRaw):

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/lss/response.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/lss/response.py
@@ -29,7 +29,7 @@ class MasterResponse(TableDataItem, abstract=True):
     _description_template = "Master {band}-band response function for absolute flux calibration"
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
-    _oca_keywords = {'PRO.CATG', 'INS.MODE', 'INS.SPEC.SETUP', 'DRS.SLIT'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.MODE', 'INS.SPEC.SETUP', 'DRS.SLIT'})
 
 
 class MasterLmResponse(BandLmMixin, MasterResponse):
@@ -47,4 +47,4 @@ class StdTransmission(TableDataItem):
     _description_template = "Transmission curve derived by means of a standard star"
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
-    _oca_keywords = {'PRO.CATG', 'INS.MODE', 'INS.SPEC.SETUP', 'DRS.SLIT'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.MODE', 'INS.SPEC.SETUP', 'DRS.SLIT'})

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/lss/rsrf.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/lss/rsrf.py
@@ -30,9 +30,9 @@ class LssRsrfRaw(Raw, abstract=True):
     _title_template = "{band} LSS RSRF raw"
     _description_template = "Raw exposure of the WCU flat field lamp through the LSS to achieve the RSRF."
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'DPR.CATG', 'DPR.TECH', 'DPR.TYPE',
-                     'INS.OPTI3.NAME', 'INS.OPTI12.NAME', 'INS.OPTI13.NAME',
-                     'DRS.SLIT'}
+    _oca_keywords = frozenset({'DPR.CATG', 'DPR.TECH', 'DPR.TYPE',
+                               'INS.OPTI3.NAME', 'INS.OPTI12.NAME', 'INS.OPTI13.NAME',
+                               'DRS.SLIT'})
 
     _schema = {
         'PRIMARY': None,
@@ -120,9 +120,9 @@ class LssRsrfPinholeRaw(ImageDataItem, abstract=True):
     _description_template = "Raw flats taken with black-body calibration lamp through the pinhole mask."
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'DPR.CATG', 'DPR.TECH', 'DPR.TYPE',
-                     'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'INS.OPTI20.NAME',
-                     'DRS.SLIT'}
+    _oca_keywords = frozenset({'DPR.CATG', 'DPR.TECH', 'DPR.TYPE',
+                              'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'INS.OPTI20.NAME',
+                              'DRS.SLIT'})
 
     _schema = {
         'PRIMARY': None,

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/lss/rsrf.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/lss/rsrf.py
@@ -54,7 +54,7 @@ class MedianLssRsrf(ImageDataItem, abstract=True):
     _description_template = "Median {band} RSRF pixel map"
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI12.NAME', 'INS.OPTI13.NAME', 'INS.OPTI14.NAME', 'DRS.SLIT'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI12.NAME', 'INS.OPTI13.NAME', 'INS.OPTI14.NAME', 'DRS.SLIT'})
 
     _schema = {
         'PRIMARY': None,
@@ -76,7 +76,7 @@ class MeanLssRsrf(ImageDataItem, abstract=True):
     _description_template = "Mean {band} RSRF pixel map"
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'DRS.SLIT'}
+    _oca_keywords = frozenset({'PRO.CATG', 'DRS.SLIT'})
 
     _schema = {
         'PRIMARY': None,
@@ -98,7 +98,7 @@ class MasterLssRsrf(ImageDataItem, abstract=True):
     _description_template = "Master {band} RSRF pixel map"
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'DRS.SLIT'}
+    _oca_keywords = frozenset({'PRO.CATG', 'DRS.SLIT'})
 
     _schema = {
         'PRIMARY': None,

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/lss/science.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/lss/science.py
@@ -30,7 +30,7 @@ class LssObjMap(ImageDataItem, abstract=True):
     _description_template = "Pixel map of object pixels (QC)"
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
-    _oca_keywords = {'PRO.CATG', 'DRS.SLIT'}
+    _oca_keywords = frozenset({'PRO.CATG', 'DRS.SLIT'})
 
     _schema = {
         'PRIMARY': None,
@@ -60,7 +60,7 @@ class LssSkyMap(ImageDataItem, abstract=True):
     _description_template = "Image with detected plain sky pixels of the {target} observation."
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'INS.OPTI11.NAME', 'DRS.SLIT'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'INS.OPTI11.NAME', 'DRS.SLIT'})
 
     _schema = {
         'PRIMARY': None,
@@ -90,7 +90,7 @@ class LssSci1d(TableDataItem, abstract=True):
     _description_template = "Extracted {band} 1D science spectrum."
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
     _frame_group = cpl.ui.Frame.FrameGroup.PRODUCT
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'INS.OPTI11.NAME', 'DRS.SLIT'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'INS.OPTI11.NAME', 'DRS.SLIT'})
 
 
 class LmLssSci1d(BandLmMixin, LssSci1d):
@@ -107,7 +107,7 @@ class LssSci2d(ImageDataItem, abstract=True):
     _description_template = "Rectified 2D {band} spectrum of science object."
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
     _frame_group = cpl.ui.Frame.FrameGroup.PRODUCT
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'INS.OPTI11.NAME', 'DRS.SLIT'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'INS.OPTI11.NAME', 'DRS.SLIT'})
 
     _schema = {
         'PRIMARY': None,
@@ -132,7 +132,7 @@ class LssSciFlux1d(TableDataItem, abstract=True):
     _description_template = "Extracted, flux-calibrated 1D science spectrum"
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
     _frame_group = cpl.ui.Frame.FrameGroup.RAW
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'INS.OPTI11.NAME', 'DRS.SLIT'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'INS.OPTI11.NAME', 'DRS.SLIT'})
 
     _schema = {
         'PRIMARY': None,
@@ -157,7 +157,7 @@ class LssSciFlux2d(ImageDataItem, abstract=True):
     _description_template = "Rectified, flux-calibrated 2D {band}-band spectrum of the science object."
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
     _frame_group = cpl.ui.Frame.FrameGroup.PRODUCT
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'INS.OPTI11.NAME', 'DRS.SLIT'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'INS.OPTI11.NAME', 'DRS.SLIT'})
 
     _schema = {
         'PRIMARY': None,
@@ -182,7 +182,7 @@ class LssSciFluxTellCorr1d(TableDataItem, abstract=True):
     _description_template = "Extracted, flux-calibrated, telluric-corrected 1D science spectrum"
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
     _frame_group = cpl.ui.Frame.FrameGroup.PRODUCT
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI12.NAME', 'INS.OPTI13.NAME', 'INS.OPTI14.NAME', 'DRS.SLIT'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI12.NAME', 'INS.OPTI13.NAME', 'INS.OPTI14.NAME', 'DRS.SLIT'})
 
 
 class LmLssSciFluxTellCorr1d(BandLmMixin, LssSciFluxTellCorr1d):

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/lss/std.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/lss/std.py
@@ -29,7 +29,7 @@ class LssStd1d(TableDataItem, abstract=True):
     _description_template = "Extracted {band} 1D standard star spectrum."
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
     _frame_group = cpl.ui.Frame.FrameGroup.PRODUCT
-    _oca_keywords = {'PRO.CATG', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'INS.OPTI11.NAME', 'DRS.SLIT'}
+    _oca_keywords = frozenset({'PRO.CATG', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME', 'INS.OPTI11.NAME', 'DRS.SLIT'})
 
 
 class LmLssStd1d(BandLmMixin, LssStd1d):
@@ -46,7 +46,7 @@ class RefStdCat(TableDataItem):
     _description_template = "Catalogue with spectra of standard reference stars"
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG'}
+    _oca_keywords = frozenset({'PRO.CATG'})
 
 
 class AoPsfModel(TableDataItem):
@@ -55,4 +55,4 @@ class AoPsfModel(TableDataItem):
     _description_template = "Model of the AO induced PSF."
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG'}
+    _oca_keywords = frozenset({'PRO.CATG'})

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/lss/trace.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/lss/trace.py
@@ -32,7 +32,7 @@ class LssTrace(TableDataItem, abstract=True):
     _description_template = "Table with polynomials describing the location of the traces on the detector"
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB  # TBC
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'DRS.SLIT'}
+    _oca_keywords = frozenset({'PRO.CATG', 'DRS.SLIT'})
 
 
 class LmLssTrace(BandLmMixin, LssTrace):

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/lss/wave.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/lss/wave.py
@@ -29,7 +29,7 @@ class LssWaveRaw(Raw, abstract=True):
     _description_template = "Raw LSS spectra of the WCU lasers in {band} band"
     _frame_group = cpl.ui.Frame.FrameGroup.RAW
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
-    _oca_keywords = {'DPR.CATG', 'DPR.TECH', 'DPR.TYPE'}
+    _oca_keywords = frozenset({'DPR.CATG', 'DPR.TECH', 'DPR.TYPE'})
 
 
 class LmLssWaveRaw(BandLmMixin, LssWaveRaw):

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/masterdark/masterdark.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/masterdark/masterdark.py
@@ -30,7 +30,7 @@ class MasterDark(ImageDataItem, abstract=True):
     _description_template = "Master dark frame for {detector} data"
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
-    _oca_keywords = {'PRO.CATG', 'DRS.FILTER'}
+    _oca_keywords = frozenset({'PRO.CATG', 'DRS.FILTER'})
 
     _schema = {
         'PRIMARY': None,

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/masterdark/raw.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/masterdark/raw.py
@@ -29,7 +29,7 @@ class DarkRaw(Raw, abstract=True):
     _description_template = r"Raw data for creating a {detector} master dark."
     _frame_level = cpl.ui.Frame.FrameLevel.FINAL
     _frame_group = cpl.ui.Frame.FrameGroup.RAW
-    _oca_keywords = {'DPR.CATG', 'DPR.TECH', 'DPR.TYPE', 'DET.ID', 'DET.DIT'}
+    _oca_keywords = frozenset({'DPR.CATG', 'DPR.TECH', 'DPR.TYPE', 'DET.ID', 'DET.DIT'})
 
 
 class Dark2rgRaw(Detector2rgMixin, DarkRaw):

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/masterdark/raw.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/masterdark/raw.py
@@ -33,12 +33,12 @@ class DarkRaw(Raw, abstract=True):
 
 
 class Dark2rgRaw(Detector2rgMixin, DarkRaw):
-    _oca_keywords = DarkRaw._oca_keywords | {'DRS.FILTER'}
+    _oca_keywords = DarkRaw._oca_keywords | frozenset({'DRS.FILTER'})
 
 
 class DarkGeoRaw(DetectorGeoMixin, DarkRaw):
-    _oca_keywords = DarkRaw._oca_keywords | {'DRS.FILTER'}
+    _oca_keywords = DarkRaw._oca_keywords | frozenset({'DRS.FILTER'})
 
 
 class DarkIfuRaw(DetectorIfuMixin, DarkRaw):
-    _oca_keywords = DarkRaw._oca_keywords | {'DRS.IFU'}
+    _oca_keywords = DarkRaw._oca_keywords | frozenset({'DRS.IFU'})

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/masterflat/masterflat.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/masterflat/masterflat.py
@@ -31,7 +31,7 @@ class MasterFlat(ImageDataItem, abstract=True):
     _description_template = "Abstract base class for master flats. Please subclass."
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
-    _oca_keywords = {'PRO.CATG', 'DRS.FILTER'}
+    _oca_keywords = frozenset({'PRO.CATG', 'DRS.FILTER'})
 
     _schema = {
         'PRIMARY': None,

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/masterflat/raw.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/masterflat/raw.py
@@ -30,8 +30,8 @@ class FlatRaw(Raw, abstract=True):
     _title_template = r'{band} flat {source} raw'
     _description_template = r'Flat raw'
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
-    _oca_keywords = {'DPR.CATG', 'DPR.TECH', 'DPR.TYPE',
-                     'INS.OPTI3.NAME', 'INS.OPTI12.NAME', 'INS.OPTI13.NAME', 'DRS.FILTER'}
+    _oca_keywords = frozenset({'DPR.CATG', 'DPR.TECH', 'DPR.TYPE',
+                              'INS.OPTI3.NAME', 'INS.OPTI12.NAME', 'INS.OPTI13.NAME', 'DRS.FILTER'})
 
     _schema = {
         'PRIMARY': None,

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/pupil/pupil.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/pupil/pupil.py
@@ -30,7 +30,7 @@ class PupilImagingReduced(ImageDataItem, abstract=True):
     _description_template = "Reduced pupil image in {band} mode."
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
-    _oca_keywords = {'PRO.CATG', 'DRS.PUPIL'}
+    _oca_keywords = frozenset({'PRO.CATG', 'DRS.PUPIL'})
 
     _schema = {
         'PRIMARY': None,

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/raw/wcuoff.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/raw/wcuoff.py
@@ -34,7 +34,7 @@ class WcuOffRaw(ImageDataItem, abstract=True):
     _description_template = "Raw data for dark subtraction in other recipes."
     _frame_group = cpl.ui.Frame.FrameGroup.RAW
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
-    _oca_keywords = {'DPR.CATG', 'DPR.TECH', 'DPR.TYPE'}
+    _oca_keywords = frozenset({'DPR.CATG', 'DPR.TECH', 'DPR.TYPE'})
 
     _schema = {
         'PRIMARY': None,

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/raw/wcuoff.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/raw/wcuoff.py
@@ -54,4 +54,4 @@ class NWcuOffRaw(BandNMixin, WcuOffRaw):
 
 
 class IfuWcuOffRaw(BandIfuMixin, WcuOffRaw):
-    _oca_keywords = WcuOffRaw._oca_keywords | {'DRS.IFU'}
+    _oca_keywords = WcuOffRaw._oca_keywords | frozenset({'DRS.IFU'})

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/rsrf/rsrf.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/rsrf/rsrf.py
@@ -29,7 +29,7 @@ class Rsrf(DataItem):
     _title_template = "RSRF"
     _description_template = "2D relative spectral response function"
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
-    _oca_keywords = {'PRO.CATG', 'DRS.IFU'}
+    _oca_keywords = frozenset({'PRO.CATG', 'DRS.IFU'})
 
     _schema = {
         'PRIMARY': None,

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/rsrf/rsrf.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/rsrf/rsrf.py
@@ -43,6 +43,7 @@ class RsrfIfu(DetectorIfuMixin, TableDataItem):
     _description_template = "1D relative spectral response function"
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
+    _oca_keywords = frozenset({'PRO.CATG', 'DRS.IFU'})
 
     _schema = {
         'PRIMARY': None,

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/wavecal.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/wavecal.py
@@ -30,9 +30,9 @@ class IfuWavecalRaw(DetectorIfuMixin, ImageDataItem):
                              "achieve the first guess of the wavelength calibration.")
     _frame_group = cpl.ui.Frame.FrameGroup.RAW
     _frame_level = cpl.ui.Frame.FrameLevel.NONE
-    _oca_keywords = {'DPR.CATG', 'DPR.TECH', 'DPR.TYPE',
-                     'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME',
-                     'DRS.IFU'}
+    _oca_keywords = frozenset({'DPR.CATG', 'DPR.TECH', 'DPR.TYPE',
+                               'INS.OPTI3.NAME', 'INS.OPTI9.NAME', 'INS.OPTI10.NAME',
+                               'DRS.IFU'})
 
 
 class IfuWavecal(DetectorIfuMixin, ImageDataItem):

--- a/metisp/pymetis/src/pymetis/instruments/metis/dataitems/wavecal.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/dataitems/wavecal.py
@@ -41,7 +41,7 @@ class IfuWavecal(DetectorIfuMixin, ImageDataItem):
     _description_template = "Image with wavelength at each pixel."
     _frame_group = cpl.ui.Frame.FrameGroup.CALIB
     _frame_level = cpl.ui.Frame.FrameLevel.INTERMEDIATE
-    _oca_keywords = {'PRO.CATG', 'DRS.IFU'}
+    _oca_keywords = frozenset({'PRO.CATG', 'DRS.IFU'})
 
     _schema = {
         'PRIMARY': None,

--- a/metisp/pymetis/src/pymetis/instruments/metis/qc/std_process.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/qc/std_process.py
@@ -18,6 +18,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 """
 
 from pymetis.engine.qc import QcParameter
+from pymetis.instruments.metis.mixins import BandLmMixin
 
 
 class QcImgStdBackgroundRms(QcParameter):

--- a/metisp/pymetis/src/pymetis/instruments/metis/recipes/lm_img/metis_lm_img_flat.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/recipes/lm_img/metis_lm_img_flat.py
@@ -30,7 +30,6 @@ class MetisLmImgFlatImpl(BandLmMixin, Detector2rgMixin, MetisBaseImgFlatImpl):
 
 
 class MetisLmImgFlat(Recipe):
-    # Fill in recipe information
     _name = "metis_lm_img_flat"
     _version = "0.1"
     _author = "A*"

--- a/metisp/pymetis/src/pymetis/instruments/metis/recipes/lm_lss/metis_lm_lss_wave.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/recipes/lm_lss/metis_lm_lss_wave.py
@@ -85,13 +85,14 @@ class MetisLmLssWaveImpl(BandLmMixin, DarkImageProcessor, MetisRecipeImpl):
             _description_template = "Degree of the first guess polynomial"
             _comment = None
 
-        class CoeffN(QcParameter):
-            _name_template = "QC LM LSS WAVE COEFF{i}"
-            _type = float
-            _unit = "pixels ^ (1 - i)"
-            _default = None
-            _description_template = "{i}-th coefficient of the first guess polynomial"
-            _comment = None
+        #class CoeffN(QcParameter):
+        #    _name_template = "QC LM LSS WAVE COEFF{i}"
+        #    _type = float
+        #    _unit = "pixels ^ (1 - i)"
+        #    _default = None
+        #    _description_template = "{i}-th coefficient of the first guess polynomial"
+        #    _comment = None
+        # FixMe: undefined keyword mixin
 
         class NLines(QcParameter):
             _name_template = "QC LM LSS WAVE NLINES"

--- a/metisp/pymetis/src/pymetis/instruments/metis/recipes/lm_lss/metis_lm_lss_wave.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/recipes/lm_lss/metis_lm_lss_wave.py
@@ -85,14 +85,13 @@ class MetisLmLssWaveImpl(BandLmMixin, DarkImageProcessor, MetisRecipeImpl):
             _description_template = "Degree of the first guess polynomial"
             _comment = None
 
-        #class CoeffN(QcParameter):
-        #    _name_template = "QC LM LSS WAVE COEFF{i}"
-        #    _type = float
-        #    _unit = "pixels ^ (1 - i)"
-        #    _default = None
-        #    _description_template = "{i}-th coefficient of the first guess polynomial"
-        #    _comment = None
-        # FixMe: undefined keyword mixin
+        class CoeffN(QcParameter):
+            _name_template = "QC LM LSS WAVE COEFF{i}"
+            _type = float
+            _unit = "pixels ^ (1 - i)"
+            _default = None
+            _description_template = "{i}-th coefficient of the first guess polynomial"
+            _comment = None
 
         class NLines(QcParameter):
             _name_template = "QC LM LSS WAVE NLINES"

--- a/metisp/pymetis/src/pymetis/instruments/metis/recipes/metis_det_lingain.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/recipes/metis_det_lingain.py
@@ -145,6 +145,7 @@ class MetisDetLinGain(Recipe):
         "Prototype to create a METIS linear gain map."
     )
 
+    _matched_keywords: frozenset[str] = frozenset()
     _algorithm = """Subtract instrument dark (hdrl_imagelist_sub_image).
     Compute mean and variance for each frame.
     Gain is determined as the slope of variance against mean (metis_derive_gain).

--- a/metisp/pymetis/src/pymetis/instruments/metis/recipes/n_img/metis_n_img_restore.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/recipes/n_img/metis_n_img_restore.py
@@ -20,12 +20,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 from pymetis.engine.core.parameter import ParameterList, ParameterValue
 from pymetis.engine.core.dummy import create_dummy_image
 from pymetis.engine.dataitems import DataItem, Hdu, PipelineProductSet
-from pymetis.engine.recipes import Recipe, RecipeImpl
+from pymetis.engine.recipes import Recipe
 from pymetis.engine.inputs import PipelineInputSet, SinglePipelineInput
 
 from pymetis.instruments.metis.dataitems.img.basicreduced import NSciCalibrated, NSciRestored
+from pymetis.instruments.metis.recipes.base import MetisRecipeImpl
 
-class MetisNImgRestoreImpl(RecipeImpl):
+
+class MetisNImgRestoreImpl(MetisRecipeImpl):
     class InputSet(PipelineInputSet):
         class CalibratedInput(SinglePipelineInput):
             Item = NSciCalibrated

--- a/metisp/pymetis/src/pymetis/instruments/metis/recipes/prefab/img/flat.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/recipes/prefab/img/flat.py
@@ -60,8 +60,8 @@ class MetisBaseImgFlatImpl(DarkImageProcessor, MetisRecipeImpl, ABC):
         BadPixMap = BadPixMap
 
     class Qc(QcParameterSet):
-        MflatRms = MFlatRms
-        MflatNBadpix = MFlatNbadpix
+        MFlatRms = MFlatRms
+        MFlatNBadpix = MFlatNbadpix
         FlatMean = FlatMean
         FlatRms = FlatRms
         FlatMedianMin = FlatMedianMin

--- a/metisp/pymetis/src/pymetis/instruments/metis/recipes/prefab/lss/sci.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/recipes/prefab/lss/sci.py
@@ -126,9 +126,7 @@ class MetisLssSciImpl(DarkImageProcessor, MetisRecipeImpl):
         WaveCalNIdent = LssWaveCalNIdent
         WaveCalNMatch = LssWaveCalNMatch
         WaveCalPolyDeg = LssWaveCalPolyDeg
-        # WaveCalPolyCoeffN = LssWaveCalPolyCoeffN # ToDo This does not work now (undefined keyword mixin)
-
-
+        WaveCalPolyCoeffN = LssWaveCalPolyCoeffN
 
 
     # CAVEAT: Dummy routine only! Will be replaced with functionality -------

--- a/metisp/pymetis/src/pymetis/instruments/metis/recipes/prefab/lss/sci.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/recipes/prefab/lss/sci.py
@@ -126,7 +126,7 @@ class MetisLssSciImpl(DarkImageProcessor, MetisRecipeImpl):
         WaveCalNIdent = LssWaveCalNIdent
         WaveCalNMatch = LssWaveCalNMatch
         WaveCalPolyDeg = LssWaveCalPolyDeg
-        WaveCalPolyCoeffN = LssWaveCalPolyCoeffN
+        # WaveCalPolyCoeffN = LssWaveCalPolyCoeffN # ToDo This does not work now (undefined keyword mixin)
 
 
 

--- a/metisp/pymetis/src/pymetis/instruments/metis/recipes/prefab/lss/std.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/recipes/prefab/lss/std.py
@@ -144,7 +144,7 @@ class MetisLssStdImpl(DarkImageProcessor, MetisRecipeImpl):
         WaveCalNIdent = LssWaveCalNIdent
         WaveCalNMatch = LssWaveCalNMatch
         WaveCalPolyDeg = LssWaveCalPolyDeg
-        # WaveCalPolyCoeffN = LssWaveCalPolyCoeffN # ToDo This does not work now (undefined keyword mixin)
+        WaveCalPolyCoeffN = LssWaveCalPolyCoeffN
 
     def process(self) -> set[DataItem]:
         # Load raw image

--- a/metisp/pymetis/src/pymetis/instruments/metis/recipes/prefab/lss/std.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/recipes/prefab/lss/std.py
@@ -144,7 +144,7 @@ class MetisLssStdImpl(DarkImageProcessor, MetisRecipeImpl):
         WaveCalNIdent = LssWaveCalNIdent
         WaveCalNMatch = LssWaveCalNMatch
         WaveCalPolyDeg = LssWaveCalPolyDeg
-        WaveCalPolyCoeffN = LssWaveCalPolyCoeffN
+        # WaveCalPolyCoeffN = LssWaveCalPolyCoeffN # ToDo This does not work now (undefined keyword mixin)
 
     def process(self) -> set[DataItem]:
         # Load raw image

--- a/metisp/pymetis/src/pymetis/instruments/metis/recipes/prefab/lss/trace.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/recipes/prefab/lss/trace.py
@@ -63,8 +63,8 @@ class MetisLssTraceImpl(DarkImageProcessor, MetisRecipeImpl):
     class Qc(QcParameterSet):
         LPolyDeg = QcLssTraceLPolyDeg
         RPolyDeg = QcLssTraceRPolyDeg
-        # LCoeff = QcLssTraceLCoeff # ToDo This need more thought, right now it will not subclass
-        # RCoeff = QcLssTraceRCoeff
+        LCoeff = QcLssTraceLCoeff
+        RCoeff = QcLssTraceRCoeff
         InterorderLevel = QcLssTraceInterorderLevel
 
     def process(self) -> set[DataItem]:

--- a/metisp/pymetis/src/pymetis/instruments/metis/recipes/prefab/lss/trace.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/recipes/prefab/lss/trace.py
@@ -63,8 +63,8 @@ class MetisLssTraceImpl(DarkImageProcessor, MetisRecipeImpl):
     class Qc(QcParameterSet):
         LPolyDeg = QcLssTraceLPolyDeg
         RPolyDeg = QcLssTraceRPolyDeg
-        LCoeff = QcLssTraceLCoeff
-        RCoeff = QcLssTraceRCoeff
+        # LCoeff = QcLssTraceLCoeff # ToDo This need more thought, right now it will not subclass
+        # RCoeff = QcLssTraceRCoeff
         InterorderLevel = QcLssTraceInterorderLevel
 
     def process(self) -> set[DataItem]:

--- a/metisp/pymetis/src/pymetis/instruments/metis/tests/recipes/instrument/test_metis_pupil_imaging.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/tests/recipes/instrument/test_metis_pupil_imaging.py
@@ -42,15 +42,18 @@ class TestRecipe(BaseRecipeTest):
     """ A bunch of extremely simple and stupid test cases... just to see if it does something """
     Recipe = Recipe
 
+    @pytest.mark.external
     @pytest.mark.parametrize("sof", [f"{recipe_name}.{band}.sof" for band in bands])
     def test_pyesorex_runs_with_zero_exit_code_and_empty_stderr(self, name, sof, create_pyesorex):
         super().test_pyesorex_runs_with_zero_exit_code_and_empty_stderr(name, sof, create_pyesorex)
 
+    @pytest.mark.external
     @pytest.mark.parametrize("sof", [f"{recipe_name}.{band}.sof" for band in bands])
     def test_recipe_can_be_run_directly(self, load_frameset, sof):
         frameset = load_frameset(sof)
         super().test_recipe_can_be_run_directly(frameset)
 
+    @pytest.mark.external
     @pytest.mark.parametrize("sof", [f"{recipe_name}.{band}.sof" for band in bands])
     def test_uses_all_input_frames(self, load_frameset, sof):
         frameset = load_frameset(sof)

--- a/metisp/pymetis/src/pymetis/instruments/metis/tests/recipes/n_img/test_metis_n_img_chopnod.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/tests/recipes/n_img/test_metis_n_img_chopnod.py
@@ -20,7 +20,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 import pytest
 
 from pymetis.instruments.metis.recipes.n_img.metis_n_img_chopnod import (MetisNImgChopnod as Recipe,
-                                                       MetisNImgChopnodImpl as Impl)
+                                                                         MetisNImgChopnodImpl as Impl)
 from pymetis.tests.classes import BaseRecipeTest, BaseInputSetTest, BaseProductSetTest
 
 

--- a/metisp/pymetis/src/pymetis/instruments/metis/tests/recipes/n_img/test_metis_n_img_flat.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/tests/recipes/n_img/test_metis_n_img_flat.py
@@ -19,9 +19,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 import pytest
 
-from pymetis.engine.recipes import Recipe, RecipeImpl
+from pymetis.engine.recipes import Recipe
 from pymetis.instruments.metis.recipes.n_img.metis_n_img_flat import (MetisNImgFlat as Recipe,
-                                                    MetisNImgFlatImpl as Impl)
+                                                                      MetisNImgFlatImpl as Impl)
 from pymetis.tests.classes import BaseRecipeTest, BaseInputSetTest, BaseProductSetTest
 
 
@@ -42,6 +42,7 @@ def sof(name: str) -> str:
 class TestRecipe(BaseRecipeTest):
     Recipe = Recipe
 
+    @pytest.mark.external
     @pytest.mark.parametrize("sof", [f"{recipe_name}.{target}.sof" for target in targets])
     def test_pyesorex_runs_with_zero_exit_code_and_empty_stderr(self, name, sof, create_pyesorex):
         super().test_pyesorex_runs_with_zero_exit_code_and_empty_stderr(name, sof, create_pyesorex)

--- a/metisp/pymetis/src/pymetis/tests/classes/inputset.py
+++ b/metisp/pymetis/src/pymetis/tests/classes/inputset.py
@@ -52,8 +52,8 @@ class BaseInputSetTest(ABC):
                 f"Input {inp.__class__.__qualname__} has not item defined"
 
     @staticmethod
-    def test_has_inputs_and_it_is_a_set(instance):
-        assert isinstance(instance.inputs, set), \
+    def test_has_inputs_and_it_is_a_frozenset(instance):
+        assert isinstance(instance.inputs, frozenset), \
             f"Inputs are not a set: {instance.inputs}"
 
     @staticmethod

--- a/metisp/pymetis/src/pymetis/tests/classes/inputset.py
+++ b/metisp/pymetis/src/pymetis/tests/classes/inputset.py
@@ -54,7 +54,7 @@ class BaseInputSetTest(ABC):
     @staticmethod
     def test_has_inputs_and_it_is_a_frozenset(instance):
         assert isinstance(instance.inputs, frozenset), \
-            f"Inputs are not a set: {instance.inputs}"
+            f"Inputs are not a frozenset: {instance.inputs}"
 
     @staticmethod
     def test_all_inputs_are_registered(instance):

--- a/metisp/pymetis/src/pymetis/tests/classes/recipe.py
+++ b/metisp/pymetis/src/pymetis/tests/classes/recipe.py
@@ -179,8 +179,8 @@ class BaseRecipeTest(ABC):
             assert isinstance(item.description(), str), \
                 f"Data item {item.__qualname__} does not have a description defined"
 
-            assert isinstance(item.oca_keywords(), set), \
-                f"Data item {item.__qualname__} does not have OCA keywords attribute defined"
+            assert isinstance(item.oca_keywords(), frozenset), \
+                f"Data item {item.__qualname__} has no OCA keywords attribute defined, or they are not a frozenset"
 
             for kw in item.oca_keywords():
                 assert isinstance(kw, str), \

--- a/metisp/pymetis/src/pymetis/tests/dataitems/test_dataitem.py
+++ b/metisp/pymetis/src/pymetis/tests/dataitems/test_dataitem.py
@@ -78,8 +78,8 @@ class TestDataItem:
             f"Data item {item.__qualname__} does not have a frame group defined!"
 
     @pytest.mark.metadata
-    def test_has_oca_keywords_defined_and_it_is_a_set(self, item):
-        assert isinstance(item._oca_keywords, set), \
+    def test_has_oca_keywords_defined_and_it_is_a_frozenset(self, item):
+        assert isinstance(item._oca_keywords, frozenset), \
             f"Data item {item.__qualname__} OCA keywords are not a set"
         #assert len(item._oca_keywords) > 0, \
         #    f"Data item {item.__qualname__} does not define any OCA keywords" # This is actually OK sometimes

--- a/runner.py
+++ b/runner.py
@@ -7,7 +7,7 @@ import inspect
 from cpl.core import Msg
 
 from metisp.pyrecipes import metis_recipes
-from pymetis.classes.recipes import MetisRecipe
+from pymetis.engine.recipes import Recipe
 
 
 def main():
@@ -20,7 +20,7 @@ def main():
     recipes = {
         recipe._name: recipe
         for name, recipe in inspect.getmembers(metis_recipes)
-        if inspect.isclass(recipe) and issubclass(recipe, MetisRecipe)
+        if inspect.isclass(recipe) and issubclass(recipe, Recipe)
     }
 
     if args.debug:


### PR DESCRIPTION
I converted the whole inheritance / parametrization mechanism into a proper metaclass, so that new hierarchies are also possible without too much repetition.

OCA keywords and such are now `frozenset`s to avoid the mutable default object problem.

Lots of minor fixes.

Tests pass, 55 completed workflows with METIS simulations via EDPS.