### PR TITLE
Fix silent polyfit failure and move filtering logic to workflows

### DIFF
--- a/metisp/pymetis/src/pymetis/instruments/metis/recipes/metis_det_lingain.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/recipes/metis_det_lingain.py
@@ -171,10 +171,8 @@ class MetisDetLinGainImpl(RawImageProcessor, MetisRecipeImpl):
        
         for i_on,un_on in enumerate(uni_on): # loop over unique dit values
    
-            if uni_on_counts[i_on] >= 2: # check if there are at least 2 frames of each DIT. This can be deferred to the workflow ?
-                # Safe-slice: uni_off_counts[uni_off == un_on] is an
-                # at-most-1-element array; bare ">= 2" on an empty slice
-                # raises "truth value of an empty array is ambiguous".
+            if uni_on_counts[i_on] >= 2: # check if there are at least 2 frames of each DIT.
+                # Safe-slice; otherwise returns "truth value of an array ... is ambiguous" error
                 off_match = uni_off_counts[uni_off == un_on]
                 if off_match.size > 0 and off_match[0] >= 2:
                     sel_dits_on=((dits == un_on) & (fws != 'open')) # this is a hack because there was no proper 'closed' position before. here open represents closed.
@@ -293,12 +291,7 @@ class MetisDetLinGainImpl(RawImageProcessor, MetisRecipeImpl):
                     sel=(fluxes_x_y<self.linlimit) # only fit pixel values within the linlimit
                     truesel=(fluxes_x_y<self.truelimit)
                     if np.sum(sel) < (self.fitdegree+1):
-                        # Not enough below-linlimit samples to fit this pixel:
-                        # mark it bad and skip (consistent with the polyfit
-                        # except: bpm[i_x,i_y]=1 path below). A whole-recipe
-                        # abort here would be too aggressive for a single
-                        # pixel; if a *lot* of pixels fall into this branch
-                        # the BPM ratio will surface it downstream.
+                        # If there are not enough below-linlimit samples to fit this pixel mark it bad and skip 
                         Msg.debug(self.__class__.__qualname__, f"Pixel ({i_x},{i_y}): too few below-linlimit samples; marking bad")
                         bpm[i_x,i_y]=1
                         continue

--- a/metisp/pymetis/src/pymetis/instruments/metis/recipes/metis_det_lingain.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/recipes/metis_det_lingain.py
@@ -211,7 +211,7 @@ class MetisDetLinGainImpl(RawImageProcessor, MetisRecipeImpl):
                    "workflow's lingain pre-filter should have caught this "
                    "earlier.")
             Msg.error(self.__class__.__qualname__, msg)
-            raise cpl.core.DataNotFoundError(msg)
+            raise cpl.core.IllegalInputError(msg)
         p,cov_p=np.polyfit(meanflux[meanflux < self.linlimit],varflux[meanflux < self.linlimit],deg=1,cov=True) # this calculates the nominal gain
         Msg.info(self.__class__.__qualname__, f"nominal gain [e/ADU]: {1/p[0]*gaincorrection_factor}")
        
@@ -268,7 +268,7 @@ class MetisDetLinGainImpl(RawImageProcessor, MetisRecipeImpl):
                        "the gain in this bootstrap window. See the comment on "
                        "the equivalent nominal-gain check above.")
                 Msg.error(self.__class__.__qualname__, msg)
-                raise cpl.core.DataNotFoundError(msg)
+                raise cpl.core.IllegalInputError(msg)
 
             p,cov_p=np.polyfit(meanflux[meanflux < self.linlimit],varflux[meanflux < self.linlimit],deg=1,cov=True)
             storegain[i_win]=1/p[0]*gaincorrection_factor

--- a/metisp/pymetis/src/pymetis/instruments/metis/recipes/metis_det_lingain.py
+++ b/metisp/pymetis/src/pymetis/instruments/metis/recipes/metis_det_lingain.py
@@ -172,7 +172,11 @@ class MetisDetLinGainImpl(RawImageProcessor, MetisRecipeImpl):
         for i_on,un_on in enumerate(uni_on): # loop over unique dit values
    
             if uni_on_counts[i_on] >= 2: # check if there are at least 2 frames of each DIT. This can be deferred to the workflow ?
-                if uni_off_counts[uni_off == un_on] >= 2:
+                # Safe-slice: uni_off_counts[uni_off == un_on] is an
+                # at-most-1-element array; bare ">= 2" on an empty slice
+                # raises "truth value of an empty array is ambiguous".
+                off_match = uni_off_counts[uni_off == un_on]
+                if off_match.size > 0 and off_match[0] >= 2:
                     sel_dits_on=((dits == un_on) & (fws != 'open')) # this is a hack because there was no proper 'closed' position before. here open represents closed.
                     sel_dits_off=((dits == un_on) & (fws == 'open')) # for a certain DIT this selects all the on and off frames.
 
@@ -201,8 +205,15 @@ class MetisDetLinGainImpl(RawImageProcessor, MetisRecipeImpl):
                 Msg.warning(self.__class__.__qualname__, "This combination does not have enough ON frames")
         dits_fluxrates=np.array(dits_fluxrates)
         if np.sum(meanflux < self.linlimit) < 2:
-            Msg.error(self.__class__.__qualname__, "This dataset does not have enough data within the linlimit to determine the gain")
-            # TODO force stop of program
+            msg = ("metis_det_lingain: not enough data points below linlimit "
+                   f"({self.linlimit}) to determine the gain "
+                   f"(meanflux={meanflux.tolist()}, uni_on={uni_on.tolist()}). "
+                   "Cause: no ON/OFF frame pairs at matching DIT, or all "
+                   "frames are above linlimit. If running under EDPS, the "
+                   "workflow's lingain pre-filter should have caught this "
+                   "earlier.")
+            Msg.error(self.__class__.__qualname__, msg)
+            raise cpl.core.DataNotFoundError(msg)
         p,cov_p=np.polyfit(meanflux[meanflux < self.linlimit],varflux[meanflux < self.linlimit],deg=1,cov=True) # this calculates the nominal gain
         Msg.info(self.__class__.__qualname__, f"nominal gain [e/ADU]: {1/p[0]*gaincorrection_factor}")
        
@@ -224,7 +235,9 @@ class MetisDetLinGainImpl(RawImageProcessor, MetisRecipeImpl):
             varflux=np.zeros([len(uni_on)])
             for i_on,un_on in enumerate(uni_on):
                 if uni_on_counts[i_on] >= 2:
-                    if uni_off_counts[uni_off == un_on] >= 2:
+                    # Safe-slice: see note at the equivalent check above.
+                    off_match = uni_off_counts[uni_off == un_on]
+                    if off_match.size > 0 and off_match[0] >= 2:
 
                         sel_dits_on=((dits == un_on) & (fws != 'open'))
                         sel_dits_off=((dits == un_on) & (fws == 'open'))
@@ -252,9 +265,13 @@ class MetisDetLinGainImpl(RawImageProcessor, MetisRecipeImpl):
                 else:
                     Msg.warning(self.__class__.__qualname__, "This combination does not have enough ON frames")
             if np.sum(meanflux < self.linlimit) < 2:
-                Msg.error(self.__class__.__qualname__, "This dataset does not have enough data within the linlimit to determine the gain")
-                # TODO force stop of program
-           
+                msg = ("metis_det_lingain (bootstrap iter): not enough data "
+                       f"points below linlimit ({self.linlimit}) to determine "
+                       "the gain in this bootstrap window. See the comment on "
+                       "the equivalent nominal-gain check above.")
+                Msg.error(self.__class__.__qualname__, msg)
+                raise cpl.core.DataNotFoundError(msg)
+
             p,cov_p=np.polyfit(meanflux[meanflux < self.linlimit],varflux[meanflux < self.linlimit],deg=1,cov=True)
             storegain[i_win]=1/p[0]*gaincorrection_factor
 
@@ -276,8 +293,15 @@ class MetisDetLinGainImpl(RawImageProcessor, MetisRecipeImpl):
                     sel=(fluxes_x_y<self.linlimit) # only fit pixel values within the linlimit
                     truesel=(fluxes_x_y<self.truelimit)
                     if np.sum(sel) < (self.fitdegree+1):
-                        Msg.error(self.__class__.__qualname__, "This pixel does not have enough data within the linlimit to perform a fit at this fitorder") # TODO this might be too restrictive, it probably needs to capture the error in poly fit and then flag these as bad pixels. And then there can be a proper error if too many pixels were flagged in this way, which could indicate that the dataset is bad.
-                    # TODO force stop of program
+                        # Not enough below-linlimit samples to fit this pixel:
+                        # mark it bad and skip (consistent with the polyfit
+                        # except: bpm[i_x,i_y]=1 path below). A whole-recipe
+                        # abort here would be too aggressive for a single
+                        # pixel; if a *lot* of pixels fall into this branch
+                        # the BPM ratio will surface it downstream.
+                        Msg.debug(self.__class__.__qualname__, f"Pixel ({i_x},{i_y}): too few below-linlimit samples; marking bad")
+                        bpm[i_x,i_y]=1
+                        continue
                    
                     # define a weighted average of the pixels below a certain 'true flux' cutoff. this defines a weighted average flux rate to which all flux rates are corrected.
                     trueflux=np.average(fluxes_x_y[truesel]/dits_fluxrates[truesel],weights=1/(np.sqrt(gaincorrection_factor)*np.sqrt(RN**2+fluxes_x_y[truesel]/(2*gain))/dits_fluxrates[truesel])**2)

--- a/metisp/workflows/metis/metis_ifu_wkf.py
+++ b/metisp/workflows/metis/metis_ifu_wkf.py
@@ -9,7 +9,7 @@ ifu_lingain_task = (task("metis_ifu_lingain")
                 .with_recipe("metis_det_lingain")
                 .with_main_input(detlin_ifu_raw)
                 .with_associated_input(badpix_map_ifu, min_ret=0)
-                .with_job_processing(instrument_to_linlimit)
+                .with_job_processing(setup_lingain_job)
                 .build())
 
 ifu_dark_task = (task("metis_ifu_dark")

--- a/metisp/workflows/metis/metis_lm_img_wkf.py
+++ b/metisp/workflows/metis/metis_lm_img_wkf.py
@@ -7,7 +7,7 @@ from .metis_task_functions import *
 lm_img_lingain_task = (task('metis_lm_img_lingain')
                 .with_main_input(detlin_2rg_raw)
                 .with_recipe("metis_det_lingain")
-                .with_job_processing(instrument_to_linlimit)
+                .with_job_processing(setup_lingain_job)
                 .build())
 
 lm_img_dark_task = (task('metis_lm_img_dark')

--- a/metisp/workflows/metis/metis_lm_lss_wkf.py
+++ b/metisp/workflows/metis/metis_lm_lss_wkf.py
@@ -29,6 +29,7 @@ lm_lss_lingain_task = (task('metis_lm_lss_lingain')
             .with_recipe("metis_det_lingain")
             .with_main_input(detlin_2rg_raw)
             .with_associated_input(lm_wcu_off_raw)        # check how that is exactly delivered by the ICS!
+            .with_job_processing(setup_lingain_job)
             .with_meta_targets([QC1_CALIB])
             .build())
 

--- a/metisp/workflows/metis/metis_n_img_wkf.py
+++ b/metisp/workflows/metis/metis_n_img_wkf.py
@@ -7,7 +7,7 @@ from .metis_task_functions import *
 n_img_lingain_task = (task('metis_n_img_lingain')
                 .with_recipe("metis_det_lingain")
                 .with_main_input(detlin_geo_raw)
-                .with_job_processing(instrument_to_linlimit)
+                .with_job_processing(setup_lingain_job)
                 .build())
 
 n_img_dark_task = (task('metis_n_img_dark')

--- a/metisp/workflows/metis/metis_n_lss_wkf.py
+++ b/metisp/workflows/metis/metis_n_lss_wkf.py
@@ -29,6 +29,7 @@ n_lss_lingain_task = (task('metis_n_lss_lingain')
             .with_recipe("metis_det_lingain")
             .with_main_input(detlin_geo_raw)
             .with_associated_input(n_wcu_off_raw)        # check how that is exactly delivered by the ICS!
+            .with_job_processing(setup_lingain_job)
             .with_meta_targets([QC1_CALIB])
             .build())
 

--- a/metisp/workflows/metis/metis_task_functions.py
+++ b/metisp/workflows/metis/metis_task_functions.py
@@ -1,8 +1,5 @@
 from collections import defaultdict
 
-import numpy as np
-from astropy.io import fits
-
 from edps import JobParameters, get_parameter, Job
 
 
@@ -47,43 +44,19 @@ def instrument_to_linlimit(job : Job):
 def _classify_lingain_frames(files):
     """Return (on_indices, off_indices, dits) for a list of DETLIN raw files.
 
-    Tries ESO DRS FILTER first ('open' = closed-shutter dark; anything else
-    = illuminated). If every frame reports 'open', fall back to a median-pixel-flux split using the first
-    image HDU of each file
+    Classification uses the ESO DRS FILTER keyword: 'open' marks a
+    closed-shutter dark (OFF), any other filter value is illuminated (ON).
+    Note: 'open' currently represents the closed position because of the
+    Shutter hack in METIS_Simulations
     """
-    dits, fws = [], []
-    for f in files:
-        dits.append(f.get_keyword_value("det.dit", None))
-        fws.append((f.get_keyword_value("drs.filter", "") or "").strip())
-
-    use_median = (not any(fw and fw != "open" for fw in fws))
-
-    on_idx, off_idx = [], []
-    if not use_median:
-        for i, fw in enumerate(fws):
-            if fw == "open":
-                off_idx.append(i)
-            elif fw:
-                on_idx.append(i)
-        return on_idx, off_idx, dits
-
-    # Median-flux fallback: read the first 2D image HDU of each file.
+    dits, on_idx, off_idx = [], [], []
     for i, f in enumerate(files):
-        median = None
-        try:
-            with fits.open(f.file_path, memmap=True) as hdul:
-                for hdu in hdul[1:]:
-                    if hdu.data is not None and getattr(hdu.data, "ndim", 0) == 2:
-                        median = float(np.median(hdu.data))
-                        break
-        except Exception:
-            median = None
-        if median is None:
-            continue
-        if median > 2000:
-            on_idx.append(i)
-        elif median < 2000:
+        dits.append(f.get_keyword_value("det.dit", None))
+        fw = (f.get_keyword_value("drs.filter", "") or "").strip()
+        if fw == "open":
             off_idx.append(i)
+        elif fw:
+            on_idx.append(i)
     return on_idx, off_idx, dits
 
 
@@ -98,6 +71,11 @@ def prefilter_lingain_inputs(job: Job) -> None:
         return
 
     on_idx, off_idx, dits = _classify_lingain_frames(files)
+
+    # If the FILTER keyword leaves the ON or OFF array empty, don't trim anything.
+    # Otherwise it would require checking pixel data, which is already done in the recipe for IFU inputs (working for LM/N) and would introduce overhead here.
+    if not on_idx or not off_idx:
+        return
 
     by_dit_on = defaultdict(list)
     by_dit_off = defaultdict(list)

--- a/metisp/workflows/metis/metis_task_functions.py
+++ b/metisp/workflows/metis/metis_task_functions.py
@@ -48,10 +48,8 @@ def _classify_lingain_frames(files):
     """Return (on_indices, off_indices, dits) for a list of DETLIN raw files.
 
     Tries ESO DRS FILTER first ('open' = closed-shutter dark; anything else
-    = illuminated). If every frame reports 'open' (the current METIS_Simulations
-    workaround state), falls back to a median-pixel-flux split using the first
-    image HDU of each file — the same heuristic the IFU branch of the recipe
-    already uses (np.median > 2000 ADU = ON).
+    = illuminated). If every frame reports 'open', fall back to a median-pixel-flux split using the first
+    image HDU of each file
     """
     dits, fws = [], []
     for f in files:
@@ -93,11 +91,7 @@ def prefilter_lingain_inputs(job: Job) -> None:
     """Drop DETLIN raws that cannot participate in a valid (ON, OFF) pair.
 
     The lingain recipe needs, for every DIT used, at least 2 ON frames and
-    2 OFF frames at that DIT. This pre-filter answers the author's "This
-    can be deferred to the workflow?" comment in metis_det_lingain.py:174 —
-    it trims job.input_files to only files at DITs with enough pairs. If
-    nothing survives, the recipe's safe abort raises cpl.core.DataNotFoundError
-    instead of crashing in polyfit.
+    2 OFF frames at that DIT.
     """
     files = list(job.input_files)
     if not files:

--- a/metisp/workflows/metis/metis_task_functions.py
+++ b/metisp/workflows/metis/metis_task_functions.py
@@ -1,3 +1,8 @@
+from collections import defaultdict
+
+import numpy as np
+from astropy.io import fits
+
 from edps import JobParameters, get_parameter, Job
 
 
@@ -35,6 +40,92 @@ def instrument_to_linlimit(job : Job):
         job.parameters.recipe_parameters[linlimit] = 13000
     elif "IFU" in subinstrument:
         job.parameters.recipe_parameters[linlimit] = 44000
-    else: 
+    else:
         print("do not recognize instrument, using default value")
-    
+
+
+def _classify_lingain_frames(files):
+    """Return (on_indices, off_indices, dits) for a list of DETLIN raw files.
+
+    Tries ESO DRS FILTER first ('open' = closed-shutter dark; anything else
+    = illuminated). If every frame reports 'open' (the current METIS_Simulations
+    workaround state), falls back to a median-pixel-flux split using the first
+    image HDU of each file — the same heuristic the IFU branch of the recipe
+    already uses (np.median > 2000 ADU = ON).
+    """
+    dits, fws = [], []
+    for f in files:
+        dits.append(f.get_keyword_value("det.dit", None))
+        fws.append((f.get_keyword_value("drs.filter", "") or "").strip())
+
+    use_median = (not any(fw and fw != "open" for fw in fws))
+
+    on_idx, off_idx = [], []
+    if not use_median:
+        for i, fw in enumerate(fws):
+            if fw == "open":
+                off_idx.append(i)
+            elif fw:
+                on_idx.append(i)
+        return on_idx, off_idx, dits
+
+    # Median-flux fallback: read the first 2D image HDU of each file.
+    for i, f in enumerate(files):
+        median = None
+        try:
+            with fits.open(f.file_path, memmap=True) as hdul:
+                for hdu in hdul[1:]:
+                    if hdu.data is not None and getattr(hdu.data, "ndim", 0) == 2:
+                        median = float(np.median(hdu.data))
+                        break
+        except Exception:
+            median = None
+        if median is None:
+            continue
+        if median > 2000:
+            on_idx.append(i)
+        elif median < 2000:
+            off_idx.append(i)
+    return on_idx, off_idx, dits
+
+
+def prefilter_lingain_inputs(job: Job) -> None:
+    """Drop DETLIN raws that cannot participate in a valid (ON, OFF) pair.
+
+    The lingain recipe needs, for every DIT used, at least 2 ON frames and
+    2 OFF frames at that DIT. This pre-filter answers the author's "This
+    can be deferred to the workflow?" comment in metis_det_lingain.py:174 —
+    it trims job.input_files to only files at DITs with enough pairs. If
+    nothing survives, the recipe's safe abort raises cpl.core.DataNotFoundError
+    instead of crashing in polyfit.
+    """
+    files = list(job.input_files)
+    if not files:
+        return
+
+    on_idx, off_idx, dits = _classify_lingain_frames(files)
+
+    by_dit_on = defaultdict(list)
+    by_dit_off = defaultdict(list)
+    for i in on_idx:
+        if dits[i] is not None:
+            by_dit_on[dits[i]].append(i)
+    for i in off_idx:
+        if dits[i] is not None:
+            by_dit_off[dits[i]].append(i)
+
+    keep_indices = set()
+    for dit, on_at_dit in by_dit_on.items():
+        off_at_dit = by_dit_off.get(dit, [])
+        if len(on_at_dit) >= 2 and len(off_at_dit) >= 2:
+            keep_indices.update(on_at_dit)
+            keep_indices.update(off_at_dit)
+
+    job.input_files = [files[i] for i in sorted(keep_indices)]
+
+
+def setup_lingain_job(job: Job) -> None:
+    """Combined job-processing for lingain tasks: set linlimit, then prefilter inputs."""
+    instrument_to_linlimit(job)
+    prefilter_lingain_inputs(job)
+


### PR DESCRIPTION
Currently metis_det_lingain crashes with an unhelpful error inside np.polyfit when the input data doesn't contain enough valid ON/OFF frame pairs at matching DITs.

This PR aims to make that failure more clear and raise `cpl.core.DataNotFoundError` when there aren't enough points to fit the gain.

Additionally I added prefiltering via the task functions of EDPS, as was suggested in the comments in `metis_det_lingain`. However, currently this means that IFU inputs (where every frame still reports open) still need to be separated in the recipe by looking at their median values.