### PR TITLE
Make everything classify

### DIFF
--- a/metisp/workflows/metis/metis_classification.py
+++ b/metisp/workflows/metis/metis_classification.py
@@ -58,7 +58,8 @@ lm_image_sci_raw_class = classification_rule("LM_IMAGE_SCI_RAW",
 
 lm_image_sky_raw_class = classification_rule("LM_IMAGE_SKY_RAW",
     {metis_kwd.instrume: "METIS",
-     metis_kwd.dpr_catg: "SCIENCE",
+     # DPR.CATG can be either CALIB or SCIENCE.
+     # metis_kwd.dpr_catg: "SCIENCE",
      metis_kwd.dpr_type: "SKY",
      metis_kwd.dpr_tech: "IMAGE,LM",
     })
@@ -130,7 +131,8 @@ n_image_sci_raw_class = classification_rule("N_IMAGE_SCI_RAW",
 
 n_image_sky_raw_class = classification_rule("N_IMAGE_SKY_RAW",
     {metis_kwd.instrume: "METIS",
-     metis_kwd.dpr_catg: "SCIENCE",
+     # DPR.CATG can be either CALIB or SCIENCE.
+     # metis_kwd.dpr_catg: "SCIENCE",
      metis_kwd.dpr_type: "SKY",
      metis_kwd.dpr_tech: "IMAGE,N",
     })
@@ -331,6 +333,14 @@ lm_lss_sci_raw_class = classification_rule("LM_LSS_SCI_RAW",
      metis_kwd.dpr_tech: "LSS,LM",
     })
 
+lm_lss_sky_raw_class = classification_rule("LM_LSS_SKY_RAW",
+    {metis_kwd.instrume: "METIS",
+     # DPR.CATG can be either CALIB or SCIENCE.
+     # metis_kwd.dpr_catg: "SCIENCE",
+     metis_kwd.dpr_type: "SKY",
+     metis_kwd.dpr_tech: "LSS,LM",
+    })
+
 # LM LSS final product (1D flux)
 lm_lss_sci_flux_1d_class = classification_rule("LM_LSS_SCI_FLUX_1D",
     {metis_kwd.instrume: "METIS",
@@ -446,6 +456,14 @@ n_lss_sci_raw_class = classification_rule("N_LSS_SCI_RAW",
     {metis_kwd.instrume: "METIS",
      metis_kwd.dpr_catg: "SCIENCE",
      metis_kwd.dpr_type: "OBJECT",
+     metis_kwd.dpr_tech: "LSS,N",
+    })
+
+n_lss_sky_raw_class = classification_rule("N_LSS_SKY_RAW",
+    {metis_kwd.instrume: "METIS",
+     # DPR.CATG can be either CALIB or SCIENCE.
+     # metis_kwd.dpr_catg: "SCIENCE",
+     metis_kwd.dpr_type: "SKY",
      metis_kwd.dpr_tech: "LSS,N",
     })
 

--- a/metisp/workflows/metis/metis_classification.py
+++ b/metisp/workflows/metis/metis_classification.py
@@ -71,6 +71,13 @@ lm_image_std_raw_class = classification_rule("LM_IMAGE_STD_RAW",
      metis_kwd.dpr_tech: "IMAGE,LM",
     })
 
+lm_off_axis_psf_raw = classification_rule("LM_OFF_AXIS_PSF_RAW",
+    {metis_kwd.instrume: "METIS",
+     metis_kwd.dpr_catg: "CALIB",
+     metis_kwd.dpr_type: "PSF,OFFAXIS",
+     metis_kwd.dpr_tech: "IMAGE,LM",
+    })
+
 # ------- N BAND CLASSIFICATIONS -----------
 
 
@@ -507,3 +514,4 @@ badpix_map_geo_class = classification_rule("BADPIX_MAP_GEO",
 n_synth_trans_class = classification_rule("N_SYNTH_TRANS",
     {metis_kwd.pro_catg: "N_SYNTH_TRANS",
     })
+

--- a/metisp/workflows/metis/metis_pupil_imaging_wkf.py
+++ b/metisp/workflows/metis/metis_pupil_imaging_wkf.py
@@ -17,6 +17,14 @@ lm_pupil_class = classification_rule("LM_PUPIL_RAW",
                                  })
 
 
+n_pupil_class = classification_rule("N_PUPIL_RAW",
+                                {"instrume":"METIS",
+                                 "dpr.catg":"TECHNICAL",
+                                 "dpr.type":"PUPIL",
+                                 "dpr.tech":"PUP,N",
+                                 })
+
+
 lm_raw_pupil = (data_source()
             .with_classification_rule(lm_pupil_class)
             .with_match_keywords(["instrume"])

--- a/metisp/workflows/metis/metis_pupil_imaging_wkf.py
+++ b/metisp/workflows/metis/metis_pupil_imaging_wkf.py
@@ -1,6 +1,6 @@
 """
 workflow definitions specific to the pupil imaging.
-Imports basic image processing from the basic imaging workflow. 
+Imports basic image processing from the basic imaging workflow.
 TODO - need N band version
 """
 
@@ -10,15 +10,15 @@ from .metis_lm_img_wkf import lm_img_lingain_task, lm_img_dark_task, lm_img_flat
 
 
 lm_pupil_class = classification_rule("LM_PUPIL_RAW",
-                                {"instrume":"METIS", 
-                                 "dpr.catg":"TECHNICAL", 
+                                {"instrume":"METIS",
+                                 "dpr.catg":"TECHNICAL",
                                  "dpr.type":"PUPIL",
                                  "dpr.tech":"PUP,LM",
                                  })
 
 
 lm_raw_pupil = (data_source()
-            .with_classification_rule(lm_pupil_class)        
+            .with_classification_rule(lm_pupil_class)
             .with_match_keywords(["instrume"])
             .build())
 

--- a/metisp/workflows/metis/metis_wkf.py
+++ b/metisp/workflows/metis/metis_wkf.py
@@ -7,3 +7,4 @@ from .metis_ifu_wkf import *
 from .metis_lm_lss_wkf import *
 from .metis_n_lss_wkf import *
 from .metis_n_img_wkf import *
+from .metis_chophome_wkf import *


### PR DESCRIPTION
As discussed this morning, we are going to use the classification rules from the pipeline also to classify the data for the archive.  Therefore, the classification rules should classify all data from METIS_Simulations.

These changes should classify all the data from METIS_Simulations. But I haven't run a full set of simulations for a while, and I didn't run the AIT tests, but this is a start.